### PR TITLE
chore: rebrand fork to claudecode-statusline

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 [Your Name]
+Copyright (c) 2026 Mithun Wijayasiri
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ There are only two things that really matter when vibe-coding: **Context Window*
 ### Quick Install (Recommended)
 
 ```bash
-npx claude-best-statusline
+npx claudecode-statusline
 ```
 
 Or with bun:
 
 ```bash
-bunx claude-best-statusline
+bunx claudecode-statusline
 ```
 
 Restart Claude Code or start a new session.
@@ -33,8 +33,8 @@ Restart Claude Code or start a new session.
 ### Clone & Install
 
 ```bash
-git clone https://github.com/TahaSabir0/claude-statusline.git
-cd claude-statusline
+git clone https://github.com/MithunWijayasiri/claudecode-statusline.git
+cd claudecode-statusline
 
 # macOS / Linux
 ./install.sh
@@ -48,7 +48,7 @@ cd claude-statusline
 1. **Download the script:**
 
    ```bash
-   curl -o ~/.claude/hooks/statusline.js https://raw.githubusercontent.com/TahaSabir0/claude-statusline/main/statusline.js
+   curl -o ~/.claude/hooks/statusline.js https://raw.githubusercontent.com/MithunWijayasiri/claudecode-statusline/main/statusline.js
    ```
 
 2. **Make it executable:**
@@ -116,7 +116,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## Credits
 
-Created by [@TahaSabir0](https://github.com/TahaSabir0)
+Created by [@MithunWijayasiri](https://github.com/MithunWijayasiri)
 
 Built for the [Claude Code](https://github.com/anthropics/claude-code) community.
 

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 
 $HOOKS_DIR = "$env:USERPROFILE\.claude\hooks"
 $SETTINGS_FILE = "$env:USERPROFILE\.claude\settings.json"
-$REPO_URL = "https://raw.githubusercontent.com/TahaSabir0/claude-statusline/main"
+$REPO_URL = "https://raw.githubusercontent.com/MithunWijayasiri/claudecode-statusline/main"
 
 Write-Host "======================================" -ForegroundColor Cyan
 Write-Host "  Claude Code Statusline Installer" -ForegroundColor Cyan
@@ -21,31 +21,11 @@ if (-not (Test-Path "$env:USERPROFILE\.claude")) {
 # Create hooks directory if it doesn't exist
 New-Item -ItemType Directory -Force -Path $HOOKS_DIR | Out-Null
 
-# Prompt user for version choice
-Write-Host "Which version would you like to install?"
-Write-Host "  1) Full version (with API usage tracking)"
-Write-Host "  2) Lite version (faster, no API calls)"
-Write-Host ""
-$choice = Read-Host "Enter your choice (1 or 2)"
-
-switch ($choice) {
-    "1" {
-        $SCRIPT_NAME = "statusline.js"
-        $VERSION_NAME = "Full version"
-    }
-    "2" {
-        $SCRIPT_NAME = "statusline-lite.js"
-        $VERSION_NAME = "Lite version"
-    }
-    default {
-        Write-Host "Invalid choice. Exiting." -ForegroundColor Red
-        exit 1
-    }
-}
+$SCRIPT_NAME = "statusline.js"
 
 # Download the script
 Write-Host ""
-Write-Host "Downloading $VERSION_NAME..." -ForegroundColor Yellow
+Write-Host "Downloading statusline..." -ForegroundColor Yellow
 
 try {
     $url = "$REPO_URL/$SCRIPT_NAME"
@@ -100,13 +80,9 @@ Write-Host "Next steps:"
 Write-Host "  1. Restart Claude Code or start a new session"
 Write-Host "  2. Your statusline should now be active!"
 Write-Host ""
-Write-Host "To switch versions:"
-Write-Host "  - Run this installer again, or"
-Write-Host "  - Edit ~/.claude/settings.json manually"
-Write-Host ""
 Write-Host "To uninstall:"
 Write-Host "  - Remove ~/.claude/hooks/$SCRIPT_NAME"
 Write-Host "  - Remove the 'statusLine' section from ~/.claude/settings.json"
 Write-Host ""
-Write-Host "For help, visit: https://github.com/TahaSabir0/claude-statusline"
+Write-Host "For help, visit: https://github.com/MithunWijayasiri/claudecode-statusline"
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 
 HOOKS_DIR="$HOME/.claude/hooks"
 SETTINGS_FILE="$HOME/.claude/settings.json"
-REPO_URL="https://raw.githubusercontent.com/TahaSabir0/claude-statusline/main"
+REPO_URL="https://raw.githubusercontent.com/MithunWijayasiri/claudecode-statusline/main"
 
 # Colors
 GREEN='\033[0;32m'
@@ -28,31 +28,11 @@ fi
 # Create hooks directory if it doesn't exist
 mkdir -p "$HOOKS_DIR"
 
-# Prompt user for version choice
-echo "Which version would you like to install?"
-echo "  1) Full version (with API usage tracking)"
-echo "  2) Lite version (faster, no API calls)"
-echo ""
-read -p "Enter your choice (1 or 2): " choice
-
-case $choice in
-    1)
-        SCRIPT_NAME="statusline.js"
-        VERSION_NAME="Full version"
-        ;;
-    2)
-        SCRIPT_NAME="statusline-lite.js"
-        VERSION_NAME="Lite version"
-        ;;
-    *)
-        echo -e "${RED}Invalid choice. Exiting.${NC}"
-        exit 1
-        ;;
-esac
+SCRIPT_NAME="statusline.js"
 
 # Download the script
 echo ""
-echo -e "${YELLOW}Downloading $VERSION_NAME...${NC}"
+echo -e "${YELLOW}Downloading statusline...${NC}"
 
 if command -v curl &> /dev/null; then
     curl -fsSL "$REPO_URL/$SCRIPT_NAME" -o "$HOOKS_DIR/$SCRIPT_NAME"
@@ -138,13 +118,9 @@ echo "Next steps:"
 echo "  1. Restart Claude Code or start a new session"
 echo "  2. Your statusline should now be active!"
 echo ""
-echo "To switch versions:"
-echo "  - Run this installer again, or"
-echo "  - Edit ~/.claude/settings.json manually"
-echo ""
 echo "To uninstall:"
 echo "  - Remove ~/.claude/hooks/$SCRIPT_NAME"
 echo "  - Remove the 'statusLine' section from ~/.claude/settings.json"
 echo ""
-echo "For help, visit: https://github.com/TahaSabir0/claude-statusline"
+echo "For help, visit: https://github.com/MithunWijayasiri/claudecode-statusline"
 echo ""

--- a/package.json
+++ b/package.json
@@ -1,10 +1,17 @@
 {
-  "name": "claude-best-statusline",
-  "version": "1.0.1",
+  "name": "claudecode-statusline",
+  "version": "1.0.0",
   "description": "A customizable statusline for Claude Code that tracks context usage and session limits",
   "bin": {
-    "claude-best-statusline": "bin/install.js"
+    "claudecode-statusline": "bin/install.js"
   },
+  "files": [
+    "bin/",
+    "statusline.js",
+    "README.md",
+    "LICENSE",
+    "preview.png"
+  ],
   "keywords": [
     "claude",
     "claude-code",
@@ -12,10 +19,14 @@
     "vibe-coding",
     "context-window"
   ],
-  "author": "TahaSabir0",
+  "author": "Mithun Wijayasiri",
   "license": "MIT",
+  "homepage": "https://github.com/MithunWijayasiri/claudecode-statusline#readme",
+  "bugs": {
+    "url": "https://github.com/MithunWijayasiri/claudecode-statusline/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TahaSabir0/claude-statusline"
+    "url": "https://github.com/MithunWijayasiri/claudecode-statusline.git"
   }
 }

--- a/statusline.js
+++ b/statusline.js
@@ -2,7 +2,7 @@
 // Claude Code Enhanced Statusline
 // Shows: directory | model | context usage | API usage (5-hour limit) | current task
 // Auto-detects API key vs subscription usage
-// https://github.com/TahaSabir0/claude-statusline
+// https://github.com/MithunWijayasiri/claudecode-statusline
 
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed package from `claude-best-statusline` to `claudecode-statusline`
  * Updated project author and repository information

* **Documentation**
  * Updated installation instructions to reference the new package name
  * Simplified installers to download a single version (previously offered multiple options)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->