### PR TITLE
fix: keep usage bar visible via cache-first reads and stale fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ The installer only does two things: it copies `statusline.js` into `~/.claude/ho
 
 ### Caching System
 
-- Usage data is cached for 30 seconds in `~/.claude/cache/usage-cache.json`
-- All sessions share the same cache
-- If API call times out, shows cached data (no lag)
+- Usage data is cached in `~/.claude/cache/usage-cache.json`, shared across all sessions
+- **Cache-first**: within 30 seconds the cache is used directly and the API call is skipped (faster renders, fewer calls)
+- **Stale fallback**: if a live API call fails or times out, the last known usage (up to 10 minutes old) is shown instead of disappearing
+- The reset countdown is recomputed on every render, so it keeps ticking even when shown from cache
 
 ### API Usage
 

--- a/statusline.js
+++ b/statusline.js
@@ -88,10 +88,16 @@ function readCachedUsage() {
     if (!fs.existsSync(USAGE_CACHE_FILE)) return null;
 
     const cache = JSON.parse(fs.readFileSync(USAGE_CACHE_FILE, 'utf8'));
-    // Ignore the legacy string-cache format from older versions.
-    if (!cache || typeof cache.data !== 'object' || cache.data === null) return null;
+    if (!cache || !Number.isFinite(cache.timestamp) || cache.timestamp <= 0) return null;
 
-    return { age: Date.now() - cache.timestamp, data: cache.data };
+    // Validate data (also rejects the legacy string-cache format from older versions),
+    // so callers never receive undefined/NaN percentage or an unparseable resetsAt.
+    const data = cache.data;
+    if (!data || typeof data !== 'object') return null;
+    if (!Number.isFinite(data.percentage) || data.percentage < 0 || data.percentage > 100) return null;
+    if (data.resetsAt != null && Number.isNaN(new Date(data.resetsAt).getTime())) return null;
+
+    return { age: Date.now() - cache.timestamp, data };
   } catch (e) {
     return null;
   }

--- a/statusline.js
+++ b/statusline.js
@@ -15,7 +15,11 @@ const IS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
 // Cache configuration
 const CACHE_DIR = path.join(os.homedir(), '.claude', 'cache');
 const USAGE_CACHE_FILE = path.join(CACHE_DIR, 'usage-cache.json');
-const CACHE_TTL_MS = 30000; // Cache valid for 30 seconds
+// Fresh: trust the cache and skip the API call entirely (fewer calls, faster render).
+const FRESH_TTL_MS = 30000;            // 30 seconds
+// Stale: used only as a fallback when a live API call fails, so the usage bar stays
+// visible through transient timeouts/errors instead of disappearing.
+const STALE_TTL_MS = 10 * 60 * 1000;   // 10 minutes
 
 // ANSI color codes
 const colors = {
@@ -57,20 +61,37 @@ function getContextBar(remaining) {
   return coloredBar;
 }
 
-// Read cached usage data
-function getCachedUsage() {
+// Render the usage bar from raw data. Called on every read (live or cached) so the
+// reset countdown is always recomputed from resetsAt rather than frozen at fetch time.
+function buildUsageBar(percentage, resetsAt) {
+  let timeStr = '';
+  if (resetsAt) {
+    const diffMins = Math.max(0, Math.floor((new Date(resetsAt) - new Date()) / 60000));
+    const hours = Math.floor(diffMins / 60);
+    const mins = diffMins % 60;
+    timeStr = hours > 0 ? `${hours}h${mins}m` : `${mins}m`;
+  }
+
+  const barWidth = 10;
+  const filledWidth = Math.max(0, Math.min(barWidth, Math.round((percentage / 100) * barWidth)));
+  const filled = '█'.repeat(filledWidth);
+  const empty = '░'.repeat(barWidth - filledWidth);
+  const color = getUsageColor(percentage);
+
+  return `${color}${filled}${empty} ${percentage}%${colors.reset}${colors.dim} (${timeStr})${colors.reset}`;
+}
+
+// Read the raw cached usage data ({ timestamp, data: { percentage, resetsAt } }).
+// Returns { age, data } or null. Age-vs-TTL decisions are made by the caller.
+function readCachedUsage() {
   try {
     if (!fs.existsSync(USAGE_CACHE_FILE)) return null;
 
     const cache = JSON.parse(fs.readFileSync(USAGE_CACHE_FILE, 'utf8'));
-    const age = Date.now() - cache.timestamp;
+    // Ignore the legacy string-cache format from older versions.
+    if (!cache || typeof cache.data !== 'object' || cache.data === null) return null;
 
-    // Return cached data if fresh enough
-    if (age < CACHE_TTL_MS) {
-      return cache.data;
-    }
-
-    return null;
+    return { age: Date.now() - cache.timestamp, data: cache.data };
   } catch (e) {
     return null;
   }
@@ -155,38 +176,11 @@ function getApiUsage(callback) {
           // Get 5-hour session usage
           if (usage.five_hour) {
             const percentage = Math.round(usage.five_hour.utilization);
-            const resetsAt = usage.five_hour.resets_at;
+            const resetsAt = usage.five_hour.resets_at || null;
 
-            // Parse reset time
-            let timeStr = '';
-            if (resetsAt) {
-              const resetDate = new Date(resetsAt);
-              const now = new Date();
-              const diffMs = resetDate - now;
-              const diffMins = Math.floor(diffMs / 60000);
-              const hours = Math.floor(diffMins / 60);
-              const mins = diffMins % 60;
-
-              if (hours > 0) {
-                timeStr = `${hours}h${mins}m`;
-              } else {
-                timeStr = `${mins}m`;
-              }
-            }
-
-            // Build bar
-            const barWidth = 10;
-            const filledWidth = Math.round((percentage / 100) * barWidth);
-            const filled = '\u2588'.repeat(filledWidth);
-            const empty = '\u2591'.repeat(barWidth - filledWidth);
-            const color = getUsageColor(percentage);
-
-            const bar = `${color}${filled}${empty} ${percentage}%${colors.reset}${colors.dim} (${timeStr})${colors.reset}`;
-
-            // Cache the result for other sessions
-            setCachedUsage(bar);
-
-            callback(bar);
+            // Cache the raw data (shared across sessions); render the bar from it.
+            setCachedUsage({ percentage, resetsAt });
+            callback(buildUsageBar(percentage, resetsAt));
           } else {
             callback(null);
           }
@@ -208,17 +202,24 @@ function getApiUsage(callback) {
   }
 }
 
-// Get usage with cache fallback
+// Get usage, cache-first.
 function getUsageWithCache(callback) {
-  // First, try to get fresh data from API
-  getApiUsage((freshData) => {
-    if (freshData) {
-      // Got fresh data, use it
-      callback(freshData);
+  const cached = readCachedUsage();
+
+  // Cache is fresh -> render it and skip the API entirely (fewer calls, faster).
+  if (cached && cached.age < FRESH_TTL_MS) {
+    return callback(buildUsageBar(cached.data.percentage, cached.data.resetsAt));
+  }
+
+  // Cache is stale or missing -> refresh from the API.
+  getApiUsage((freshBar) => {
+    if (freshBar) {
+      callback(freshBar);
+    } else if (cached && cached.age < STALE_TTL_MS) {
+      // API failed/timed out, but recent cache exists -> show it instead of nothing.
+      callback(buildUsageBar(cached.data.percentage, cached.data.resetsAt));
     } else {
-      // API failed or timed out, try cache
-      const cachedData = getCachedUsage();
-      callback(cachedData);
+      callback(null);
     }
   });
 }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -142,6 +142,8 @@ test('stale cache + failing API -> usage stays visible (does not disappear)', ()
 
 test('expired cache + failing API -> usage omitted', () => {
   const home = seedHome({ cacheAgeMs: 20 * 60 * 1000, percentage: 57 }); // > STALE_TTL (10m)
-  const { clean } = run(fixture(40), { home, usage: true });
+  const { code, clean } = run(fixture(40), { home, usage: true });
+  assert.strictEqual(code, 0);                                  // ran successfully
+  assert.ok(clean.includes('context:'), 'expected the normal line to still render');
   assert.ok(!clean.includes('usage:'), 'usage should be omitted once cache is too old');
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -16,21 +16,39 @@ const FAKE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-test-'));
 after(() => fs.rmSync(FAKE_HOME, { recursive: true, force: true }));
 
 // Run statusline.js with the given stdin string. Returns { code, raw, clean }.
-function run(input) {
-  const res = spawnSync(process.execPath, [SCRIPT], {
-    input,
-    encoding: 'utf8',
-    timeout: 5000,
-    env: {
-      ...process.env,
-      ANTHROPIC_API_KEY: 'test',   // skip the usage fetch (existence is all the script checks)
-      HOME: FAKE_HOME,             // *nix: no ~/.claude
-      USERPROFILE: FAKE_HOME       // Windows: no ~/.claude
-    }
-  });
+// opts.home  : override the fake HOME (default: empty FAKE_HOME -> no usage/todos)
+// opts.usage : when true, allow the usage path to run (otherwise a dummy
+//              ANTHROPIC_API_KEY is set so the usage fetch is skipped entirely)
+function run(input, opts = {}) {
+  const home = opts.home || FAKE_HOME;
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  if (opts.usage) {
+    delete env.ANTHROPIC_API_KEY;
+  } else {
+    env.ANTHROPIC_API_KEY = 'test';
+  }
+  const res = spawnSync(process.execPath, [SCRIPT], { input, encoding: 'utf8', timeout: 5000, env });
   const raw = res.stdout || '';
   const clean = raw.replace(/\x1b\[[0-9;]*m/g, ''); // strip ANSI for readable assertions
   return { code: res.status, raw, clean };
+}
+
+// Build a throwaway HOME containing a tokenless credentials file (so getApiUsage
+// bails out before any network/keychain call) and optionally a seeded usage cache
+// of a given age. Lets us exercise the cache-first / stale-fallback logic offline.
+function seedHome({ cacheAgeMs, percentage = 42 } = {}) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-cache-'));
+  const claudeDir = path.join(home, '.claude');
+  fs.mkdirSync(path.join(claudeDir, 'cache'), { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, '.credentials.json'), '{}'); // no accessToken -> API skipped
+  if (cacheAgeMs != null) {
+    const cache = {
+      timestamp: Date.now() - cacheAgeMs,
+      data: { percentage, resetsAt: new Date(Date.now() + 2 * 3600 * 1000).toISOString() }
+    };
+    fs.writeFileSync(path.join(claudeDir, 'cache', 'usage-cache.json'), JSON.stringify(cache));
+  }
+  return home;
 }
 
 function fixture(remaining, dir = '/tmp/myproject', model = 'Opus 4.8') {
@@ -104,4 +122,26 @@ test('missing fields -> no crash, exit 0', () => {
   assert.strictEqual(code, 0);
   assert.ok(clean.includes('Claude'));                 // default model name
   assert.ok(clean.includes('context:'));
+});
+
+// Usage bar: cache-first behavior and the stale fallback that fixes the
+// "usage section disappears mid-session" bug.
+
+test('fresh cache -> usage rendered from cache (no API call)', () => {
+  const home = seedHome({ cacheAgeMs: 5000, percentage: 42 }); // < FRESH_TTL (30s)
+  const { code, clean } = run(fixture(40), { home, usage: true });
+  assert.strictEqual(code, 0);
+  assert.match(clean, /usage: .* 42%/);
+});
+
+test('stale cache + failing API -> usage stays visible (does not disappear)', () => {
+  const home = seedHome({ cacheAgeMs: 2 * 60 * 1000, percentage: 57 }); // > FRESH, < STALE
+  const { clean } = run(fixture(40), { home, usage: true });
+  assert.match(clean, /usage: .* 57%/);
+});
+
+test('expired cache + failing API -> usage omitted', () => {
+  const home = seedHome({ cacheAgeMs: 20 * 60 * 1000, percentage: 57 }); // > STALE_TTL (10m)
+  const { clean } = run(fixture(40), { home, usage: true });
+  assert.ok(!clean.includes('usage:'), 'usage should be omitted once cache is too old');
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified caching behavior: cross-session cache sharing, 30s cache-first use, up-to-~10min stale fallback on API failures, and that reset countdown is recomputed on each render.

* **Improvements**
  * Two-tier cache TTL behavior so fresh cache is used immediately and stale cache is used only as a fallback when live fetch fails.

* **Tests**
  * Added offline-capable tests verifying fresh, stale-fallback, and expired cache behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->