### PR TITLE
fix: rename package and commands to ctxline-claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Two metrics have the biggest impact on a Claude Code session: **context window u
 ### Quick Install (Recommended)
 
 ```bash
-npx claudecode-statusline
+npx ctxline-claude
 ```
 
 Or with bun:
 
 ```bash
-bunx claudecode-statusline
+bunx ctxline-claude
 ```
 
 Restart Claude Code or start a new session.
@@ -77,7 +77,7 @@ cd claudecode-statusline
 ### Quick Uninstall (Recommended)
 
 ```bash
-npx claudecode-statusline uninstall
+npx ctxline-claude uninstall
 ```
 
 This removes the `statusLine` entry from `~/.claude/settings.json` (backing the file up first, and leaving any other settings intact), deletes `~/.claude/hooks/statusline.js`, and clears the cached usage data. Restart Claude Code afterward. If `settings.json` points to a different statusline, it's left untouched.

--- a/bin/install.js
+++ b/bin/install.js
@@ -16,7 +16,7 @@ const yellow = '\x1b[33m';
 const cyan = '\x1b[36m';
 const reset = '\x1b[0m';
 
-// Uninstall mode: `npx claudecode-statusline uninstall` (additive — plain install is unchanged)
+// Uninstall mode: `npx ctxline-claude uninstall` (additive — plain install is unchanged)
 const mode = (process.argv[2] || '').toLowerCase();
 if (mode === 'uninstall' || mode === 'remove') {
   runUninstall();

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "claudecode-statusline",
-  "version": "1.0.0",
+  "name": "ctxline-claude",
+  "version": "0.0.1",
   "description": "A customizable statusline for Claude Code that tracks context usage and session limits",
   "bin": {
-    "claudecode-statusline": "bin/install.js"
+    "ctxline-claude": "bin/install.js"
   },
   "scripts": {
     "test": "node --test",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rebranded package with updated CLI command name
  * Bumped version to 0.0.1

* **Documentation**
  * Updated installation and uninstallation instructions with new command names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->