### PR TITLE
ci: add manual GitHub release workflow with statusline preview

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Resolve tag
         id: ver
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.version }}   # via env, never interpolated into the script
         run: |
-          V="${{ github.event.inputs.version }}"
+          V="$VERSION_INPUT"
           if [ -z "$V" ]; then V="$(node -p "require('./package.json').version")"; fi
+          if ! printf '%s' "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$'; then
+            echo "::error::Invalid version '$V' — expected semver like 1.2.3."
+            exit 1
+          fi
           echo "tag=v$V" >> "$GITHUB_OUTPUT"
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+# Manually triggered after an npm publish. Creates a GitHub release with:
+# - the statusline preview (colors stripped, GitHub markdown can't render ANSI)
+# - auto-generated notes from commits/PRs since the previous release
+# - Source code (zip/tar.gz), which GitHub attaches automatically
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version without the leading 'v' (blank = use package.json version)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write   # required to create the tag + release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve tag
+        id: ver
+        run: |
+          V="${{ github.event.inputs.version }}"
+          if [ -z "$V" ]; then V="$(node -p "require('./package.json').version")"; fi
+          echo "tag=v$V" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        run: npm test
+
+      - name: Render statusline preview
+        run: node scripts/preview.js | perl -pe 's/\x1b\[[0-9;]*m//g' > preview.txt
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::Release $TAG already exists — bump the version in package.json first."
+            exit 1
+          fi
+
+          NOTES="$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$TAG" -f target_commitish="$GITHUB_SHA" --jq .body)"
+
+          {
+            echo "### Statusline preview"
+            echo ""
+            echo "_Sample line — colors render in a real terminal; stripped here._"
+            echo ""
+            echo '```text'
+            cat preview.txt
+            echo '```'
+            echo ""
+            echo "$NOTES"
+          } > body.md
+
+          gh release create "$TAG" --title "$TAG" --notes-file body.md

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -38,7 +38,14 @@ function render({ dir, model, remaining, usage, resetsInMin }) {
     timeout: 5000,
     env
   });
-  return (res.stdout || '').trim();
+
+  if (res.error) throw res.error;
+  if (res.status !== 0) {
+    throw new Error(`statusline.js exited with ${res.status}\n${res.stderr || ''}`);
+  }
+  const out = (res.stdout || '').trim();
+  if (!out) throw new Error(`statusline.js produced no output\n${res.stderr || ''}`);
+  return out;
 }
 
 console.log(render({

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -1,5 +1,9 @@
-// Renders sample statuslines so CI logs show how it looks on each platform.
-// Not a test and not published — just a visual sanity check across OSes.
+// Renders one real statusline line (including the usage bar) so CI logs and the
+// GitHub release show what you actually get in the Claude Code CLI.
+//
+// The usage bar normally needs a live session. Here we seed a fresh usage cache
+// (+ a tokenless credentials file) in a throwaway HOME, so the real statusline.js
+// renders the usage segment from cache without any network call.
 
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
@@ -7,39 +11,40 @@ const os = require('node:os');
 const path = require('node:path');
 
 const SCRIPT = path.join(__dirname, '..', 'statusline.js');
-const FAKE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-preview-'));
-process.on('exit', () => fs.rmSync(FAKE_HOME, { recursive: true, force: true }));
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-preview-'));
+process.on('exit', () => fs.rmSync(TMP, { recursive: true, force: true }));
 
-function render(input) {
+function render({ dir, model, remaining, usage, resetsInMin }) {
+  const home = fs.mkdtempSync(path.join(TMP, 'home-'));
+  const cacheDir = path.join(home, '.claude', 'cache');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), '{}'); // no token -> no network
+  fs.writeFileSync(path.join(cacheDir, 'usage-cache.json'), JSON.stringify({
+    timestamp: Date.now(),                                  // fresh -> cache-first renders it
+    data: { percentage: usage, resetsAt: new Date(Date.now() + resetsInMin * 60000).toISOString() }
+  }));
+
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  delete env.ANTHROPIC_API_KEY;                             // let the usage path run
+
   const res = spawnSync(process.execPath, [SCRIPT], {
-    input,
+    input: JSON.stringify({
+      model: { display_name: model },
+      workspace: { current_dir: dir },
+      session_id: 'preview',
+      context_window: { remaining_percentage: remaining }
+    }),
     encoding: 'utf8',
     timeout: 5000,
-    env: { ...process.env, ANTHROPIC_API_KEY: 'preview', HOME: FAKE_HOME, USERPROFILE: FAKE_HOME }
+    env
   });
-  return res.stdout || '';
+  return (res.stdout || '').trim();
 }
 
-function fixture(remaining, dir, model) {
-  return JSON.stringify({
-    model: { display_name: model },
-    workspace: { current_dir: dir },
-    session_id: 'preview',
-    context_window: { remaining_percentage: remaining }
-  });
-}
-
-const scenarios = [
-  ['green   (20% used)', fixture(80, '/home/me/api-server', 'Haiku 4.5')],
-  ['yellow  (58% used)', fixture(42, '/home/me/web-app', 'Sonnet 4.6')],
-  ['orange  (72% used)', fixture(28, '/home/me/data-pipeline', 'Opus 4.8')],
-  ['red+skull (94% used)', fixture(6, '/home/me/big-refactor', 'Opus 4.8')],
-  ['fallback (no/invalid stdin)', '']
-];
-
-console.log(`\nStatusline preview — ${os.platform()} ${os.arch()}, node ${process.version}`);
-console.log('Note: the usage bar needs a live session and is not shown here.\n');
-for (const [label, input] of scenarios) {
-  console.log(`  ${label.padEnd(28)} ${render(input)}`);
-}
-console.log('');
+console.log(render({
+  dir: '/home/me/my-project',
+  model: 'Opus 4.8 (1M context)',
+  remaining: 100,   // context 0% used
+  usage: 14,
+  resetsInMin: 21   // renders ~(20m)
+}));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual release workflow to streamline creating validated, consistent releases with automated note generation and a statusline preview.
  * Simplified preview rendering for CI: single, deterministic statusline output usable in automated checks without external credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->