### PR TITLE
Refactor/usage from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 
 ## How it works
 
-- **Source** — context comes from Claude Code's session data; both usage bars are fetched from `https://api.anthropic.com/api/oauth/usage` (the `/usage` data — 5-hour and weekly limits). API-key users skip the usage fetch.
-- **Adaptive timing** — 1.5s timeout on the first prompt (cold start), 1.2s after (connection reused).
-- **Caching** — usage is cached at `~/.claude/cache/usage-cache.json`, shared across sessions. Within 30s the cache renders directly (the API call is skipped); if a live call fails, the last value (up to 10 min old) is shown so the bar never vanishes. The reset countdown recomputes every render.
+- **Source** — context comes from Claude Code's session data. Usage bars are read straight from the `rate_limits` field Claude Code pipes in (no network), falling back to `https://api.anthropic.com/api/oauth/usage` (the same `/usage` data — 5-hour and weekly limits) when that field isn't present yet. API-key users skip usage entirely.
+- **No network on the fast path** — when `rate_limits` is in the session data, there's no API call at all. The fetch below only runs as a fallback (e.g. the first render of a session, before the field appears).
+- **Adaptive timing** — for the fallback fetch: 1.5s timeout on the first prompt (cold start), 1.2s after (connection reused).
+- **Caching** — the fallback fetch is cached at `~/.claude/cache/usage-cache.json`, shared across sessions. Within 30s the cache renders directly (the API call is skipped); if a live call fails, the last value (up to 10 min old) is shown so the bar never vanishes. The reset countdown recomputes every render.
 - **Never breaks** — every failure path falls back silently; the statusline always prints.
 
 ## FAQ
@@ -120,7 +121,7 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 <details>
 <summary>Does this use the same data as /usage?</summary>
 
-Yes. Usage information comes directly from Anthropic's usage API.
+Yes — the same 5-hour and weekly limits. It reads them from the session data Claude Code provides when available, and falls back to Anthropic's usage API (the endpoint `/usage` uses) otherwise.
 
 </details>
 
@@ -141,7 +142,7 @@ No. All failures are handled silently and the statusline always renders.
 <details>
 <summary>Does it expose my API keys / auth tokens?</summary>
 
-No. Your credentials never leave your machine. The OAuth token is read locally (from `~/.claude/.credentials.json` or the macOS keychain) only to authenticate the request to Anthropic's own usage API — the same endpoint `/usage` uses. Nothing is sent to any third party, logged, or cached; only the resulting usage percentages are stored locally.
+No. Your credentials never leave your machine. On the fast path no token is read at all — usage comes straight from the session data. Only on the fallback fetch is the OAuth token read locally (from `~/.claude/.credentials.json` or the macOS keychain), used solely to authenticate the request to Anthropic's own usage API — the same endpoint `/usage` uses. Nothing is sent to any third party, logged, or cached; only the resulting usage percentages are stored locally.
 
 </details>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -357,8 +357,8 @@
     </div>
     <div class="steps">
       <div class="step"><div class="n">01</div><h4>Reads session</h4><p>Context comes straight from Claude Code's session data on every render.</p></div>
-      <div class="step"><div class="n">02</div><h4>Fetches usage</h4><p>5-hour and weekly limits come from Anthropic's own usage API — credentials never leave your machine.</p></div>
-      <div class="step"><div class="n">03</div><h4>Caches it</h4><p>Usage is cached and shared across sessions, with adaptive timeouts so the line stays snappy.</p></div>
+      <div class="step"><div class="n">02</div><h4>Reads usage</h4><p>5-hour and weekly limits come from the session data — no network. It falls back to Anthropic's usage API when needed; credentials never leave your machine.</p></div>
+      <div class="step"><div class="n">03</div><h4>Caches it</h4><p>The fallback fetch is cached and shared across sessions, with adaptive timeouts so the line stays snappy.</p></div>
       <div class="step"><div class="n">04</div><h4>Falls back</h4><p>Every failure path degrades silently to cached or partial output. The statusline always renders.</p></div>
     </div>
   </section>
@@ -411,7 +411,7 @@
        desc:'Context-window usage. The bar shifts color as it fills toward the limit.',
        tok:'<span class="lbl">CTX</span> '+bar(3)+' <span class="pct">45%</span>'},
       {tag:'5H',      title:'5-hour session',  field:'rate_limits.five_hour',
-       desc:'Live 5-hour session limit with a reset countdown, pulled from the usage API.',
+       desc:'Live 5-hour session limit with a reset countdown, read straight from your session data.',
        tok:'<span class="lbl">5h</span> '+bar(1)+' <span class="pct">14%</span> <span class="dim">(4h20m)</span>'},
       {tag:'7D',      title:'Weekly allowance',field:'rate_limits.seven_day',
        desc:'Your weekly usage and the time remaining until the weekly reset.',

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -14,18 +14,22 @@ const SCRIPT = path.join(__dirname, '..', 'statusline.js');
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-preview-'));
 process.on('exit', () => fs.rmSync(TMP, { recursive: true, force: true }));
 
-function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort }) {
+function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort, rateLimits }) {
   const home = fs.mkdtempSync(path.join(TMP, 'home-'));
   const cacheDir = path.join(home, '.claude', 'cache');
   fs.mkdirSync(cacheDir, { recursive: true });
-  fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), '{}'); // no token -> no network
-  fs.writeFileSync(path.join(cacheDir, 'usage-cache.json'), JSON.stringify({
-    timestamp: Date.now(),                                  // fresh -> cache-first renders it
-    data: {
-      fiveHour: { percentage: current, resetsAt: new Date(Date.now() + currentResetsInMin * 60000).toISOString() },
-      weekly: { percentage: weekly, resetsAt: new Date(Date.now() + weeklyResetsInMin * 60000).toISOString() }
-    }
-  }));
+  // rateLimits scenario seeds neither creds nor cache, proving the stdin path bypasses
+  // the network/cache flow entirely. Otherwise seed a fresh cache (cache-first renders it).
+  if (!rateLimits) {
+    fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), '{}'); // no token -> no network
+    fs.writeFileSync(path.join(cacheDir, 'usage-cache.json'), JSON.stringify({
+      timestamp: Date.now(),                                  // fresh -> cache-first renders it
+      data: {
+        fiveHour: { percentage: current, resetsAt: new Date(Date.now() + currentResetsInMin * 60000).toISOString() },
+        weekly: { percentage: weekly, resetsAt: new Date(Date.now() + weeklyResetsInMin * 60000).toISOString() }
+      }
+    }));
+  }
 
   // Real on-disk dir with a seeded .git/HEAD so the branch segment renders (statusline.js
   // reads .git/HEAD directly). basename(currentDir) keeps the displayed dir name.
@@ -42,7 +46,8 @@ function render({ dir, model, remaining, current, currentResetsInMin, weekly, we
       workspace: { current_dir: projectDir },
       session_id: 'preview',
       context_window: { remaining_percentage: remaining },
-      effort: { level: effort }
+      effort: { level: effort },
+      ...(rateLimits ? { rate_limits: rateLimits } : {})
     }),
     encoding: 'utf8',
     timeout: 5000,
@@ -78,3 +83,16 @@ console.log('\nThinking-effort levels:');
 for (const effort of ['xhigh', 'max', 'ultracode']) {
   console.log(`  ${effort.padEnd(9)} ${render({ ...base, effort })}`);
 }
+
+// Usage from stdin `rate_limits` (Pro/Max post-first-response): no cache, no creds.
+// resets_at is a Unix epoch in seconds. Renders the same 5h/7d bars as the cache path.
+const nowSec = Math.floor(Date.now() / 1000);
+console.log('\nUsage from stdin rate_limits (no cache / no creds):');
+console.log('  ' + render({
+  ...base,
+  effort: 'high',
+  rateLimits: {
+    five_hour: { used_percentage: base.current, resets_at: nowSec + base.currentResetsInMin * 60 },
+    seven_day: { used_percentage: base.weekly, resets_at: nowSec + base.weeklyResetsInMin * 60 }
+  }
+}));

--- a/statusline.js
+++ b/statusline.js
@@ -163,6 +163,31 @@ function normalizePercentage(value) {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
+// Build usage bars from stdin `rate_limits` (Claude.ai Pro/Max, present only after the
+// first API response of a session). Same data as the OAuth usage API, so reading it here
+// skips the network/credentials/cache path entirely. `resets_at` is a Unix epoch in
+// SECONDS (not ISO) — ×1000 before Date. Returns { current, weekly } bars, or null when
+// rate_limits is absent or the required five_hour segment is unusable (caller falls back).
+function buildUsageFromStdin(data) {
+  const rl = data?.rate_limits;
+  if (!rl) return null;
+
+  const toEntry = (seg) => {
+    if (!seg) return null;
+    const pct = normalizePercentage(seg.used_percentage);
+    if (pct == null) return null;
+    return {
+      percentage: pct,
+      resetsAt: seg.resets_at ? new Date(seg.resets_at * 1000).toISOString() : null
+    };
+  };
+
+  const fiveHour = toEntry(rl.five_hour);
+  if (!fiveHour) return null;          // five_hour is the required bar
+  const weekly = toEntry(rl.seven_day);
+  return buildUsageBars(fiveHour, weekly);
+}
+
 // Validate a single usage entry ({ percentage, resetsAt }). Returns true only for a
 // finite 0-100 percentage and a parseable (or absent) resetsAt.
 function isValidUsageEntry(entry) {
@@ -393,21 +418,45 @@ function outputFallback(usage) {
   process.stdout.write(parts.join(' \u2502 '));
 }
 
-// Wrapper that skips usage fetch for API key users
-function getUsage(callback) {
+// Resolve usage bars for a (possibly null) parsed stdin payload.
+// Order: API-key users get none; otherwise prefer stdin `rate_limits` (no network),
+// then fall back to the cache+API flow when stdin lacks it (cold start / non-Pro/Max).
+function resolveUsage(data, callback) {
   if (IS_API_KEY) {
-    callback(null);
-  } else {
-    getUsageWithCache(callback);
+    return callback(null);
   }
+  const fromStdin = buildUsageFromStdin(data);
+  if (fromStdin) {
+    return callback(fromStdin);
+  }
+  getUsageWithCache(callback);
 }
 
 // Process with timeout
-if (process.stdin.isTTY) {
-  getUsage((usage) => {
-    outputFallback(usage);
+// Parse the accumulated stdin into a payload object, or null if empty/unparseable.
+function parseInput(input) {
+  if (!input || input.length === 0) return null;
+  try {
+    return JSON.parse(input);
+  } catch (e) {
+    return null;
+  }
+}
+
+// Resolve usage for `data` (preferring stdin rate_limits), then render and exit.
+function emit(data) {
+  resolveUsage(data, (usage) => {
+    if (data) {
+      outputStatus(data, usage);
+    } else {
+      outputFallback(usage);
+    }
     process.exit(0);
   });
+}
+
+if (process.stdin.isTTY) {
+  emit(null);
 } else {
   let input = '';
   let timeoutReached = false;
@@ -416,19 +465,7 @@ if (process.stdin.isTTY) {
 
   const timeout = setTimeout(() => {
     timeoutReached = true;
-    getUsage((usage) => {
-      if (input.length > 0) {
-        try {
-          const data = JSON.parse(input);
-          outputStatus(data, usage);
-        } catch (e) {
-          outputFallback(usage);
-        }
-      } else {
-        outputFallback(usage);
-      }
-      process.exit(0);
-    });
+    emit(parseInput(input));
   }, overallTimeout);
 
   process.stdin.setEncoding('utf8');
@@ -436,15 +473,6 @@ if (process.stdin.isTTY) {
   process.stdin.on('end', () => {
     if (timeoutReached) return;
     clearTimeout(timeout);
-
-    getUsage((usage) => {
-      try {
-        const data = JSON.parse(input);
-        outputStatus(data, usage);
-      } catch (e) {
-        outputFallback(usage);
-      }
-      process.exit(0);
-    });
+    emit(parseInput(input));
   });
 }

--- a/statusline.js
+++ b/statusline.js
@@ -176,10 +176,16 @@ function buildUsageFromStdin(data) {
     if (!seg) return null;
     const pct = normalizePercentage(seg.used_percentage);
     if (pct == null) return null;
-    return {
-      percentage: pct,
-      resetsAt: seg.resets_at ? new Date(seg.resets_at * 1000).toISOString() : null
-    };
+    // resets_at is a Unix epoch in SECONDS. Coerce + validate defensively: a non-numeric
+    // or out-of-range value would make new Date(...).toISOString() throw, and this path
+    // runs outside outputStatus's try/catch. Fall back to resetsAt: null on anything bad.
+    let resetsAt = null;
+    const epoch = Number(seg.resets_at);
+    if (Number.isFinite(epoch) && epoch > 0) {
+      const d = new Date(epoch * 1000);
+      if (!Number.isNaN(d.getTime())) resetsAt = d.toISOString();
+    }
+    return { percentage: pct, resetsAt };
   };
 
   const fiveHour = toEntry(rl.five_hour);

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -66,6 +66,22 @@ function fixture(remaining, dir = '/tmp/myproject', model = 'Opus 4.8', effort) 
   return JSON.stringify(obj);
 }
 
+// stdin payload carrying `rate_limits` (Claude.ai Pro/Max, post-first-response).
+// resets_at is a Unix epoch in SECONDS. 5h ~2h out, 7d ~62h out (exercises day-aware countdown).
+function fixtureWithRateLimits(remaining, { five = 23.5, seven = 41.2 } = {}) {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return JSON.stringify({
+    model: { display_name: 'Opus 4.8' },
+    workspace: { current_dir: '/tmp/myproject' },
+    session_id: 'test-session',
+    context_window: { remaining_percentage: remaining },
+    rate_limits: {
+      five_hour: { used_percentage: five, resets_at: nowSec + 2 * 3600 },
+      seven_day: { used_percentage: seven, resets_at: nowSec + 62 * 3600 }
+    }
+  });
+}
+
 // Make a real dir with a seeded .git/HEAD so the branch segment renders deterministically.
 function seedRepo(branch = 'feature/x') {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-repo-'));
@@ -256,4 +272,24 @@ test('expired cache + failing API -> usage omitted', () => {
   assert.ok(clean.includes('CTX'), 'expected the normal line to still render');
   assert.ok(!clean.includes('5h '), 'current usage should be omitted once cache is too old');
   assert.ok(!clean.includes('7d '), 'weekly usage should be omitted once cache is too old');
+});
+
+// Usage from stdin `rate_limits`: the network/cache path is bypassed entirely.
+
+test('stdin rate_limits -> 5h/7d render with no cache and no creds', () => {
+  // FAKE_HOME has neither a usage cache nor a credentials file, so the only way usage
+  // can render is straight from stdin rate_limits (proves the API/cache path is skipped).
+  const { code, clean } = run(fixtureWithRateLimits(40), { usage: true });
+  assert.strictEqual(code, 0);
+  assert.match(clean, /5h .* 24%/);                             // 23.5 -> 24 (fractional, rounded)
+  assert.match(clean, /7d .* 41%/);                             // 41.2 -> 41
+  assert.match(clean, /7d .* 41% \(2d\d{1,2}h\)/);              // epoch-seconds -> day-aware countdown
+});
+
+test('stdin rate_limits takes precedence over a fresh cache', () => {
+  // Fresh cache says 42% / 31%; stdin says 23.5% / 41.2%. stdin must win (cache not read).
+  const home = seedHome({ cacheAgeMs: 5000, percentage: 42, weeklyPercentage: 31 });
+  const { clean } = run(fixtureWithRateLimits(40), { home, usage: true });
+  assert.match(clean, /5h .* 24%/);
+  assert.ok(!clean.includes('42%'), 'cached 5h value must not appear when stdin rate_limits is present');
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage bars now prefer session-provided rate limits for faster, no-network rendering; a fallback to the usage API occurs only when session data is absent. Preview tooling can be driven by stdin payloads to render usage without reading local credentials.

* **Documentation**
  * Clarified how usage is sourced, confirmed credentials remain local and are never transmitted, and explained the fallback behavior.

* **Tests**
  * Added tests verifying stdin-provided usage overrides caches and renders correctly without credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->