### PR TITLE
fix(release): show only primary line in GitHub release preview

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
         run: npm publish
 
       - name: Render statusline preview
-        run: node scripts/preview.js | perl -pe 's/\x1b\[[0-9;]*m//g' > preview.txt
+        # preview.js prints several scenarios for the CI visual sync-check; 
+        # the release body only wants the primary line (first line), colors stripped.
+        run: node scripts/preview.js | perl -pe 's/\x1b\[[0-9;]*m//g' | head -n 1 > preview.txt
 
       - name: Create release
         env:

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -74,7 +74,8 @@ const base = {
   weeklyResetsInMin: 3720    // renders ~(2d14h)
 };
 
-// Primary line (default effort).
+// Primary line (default effort). NOTE: this MUST stay the first printed line —
+// the release workflow takes only line 1 (`head -n 1`) for the GitHub release body.
 console.log(render({ ...base, effort: 'high' }));
 
 // Thinking-effort color variants: only the top two levels are highlighted.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal release automation to streamline GitHub release body generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->