### PR TITLE
chore: rename repo references to ctxline-claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
     <img src="https://img.shields.io/npm/dm/ctxline-claude" alt="npm downloads">
   </a>
   <a href="LICENSE">
-    <img src="https://img.shields.io/github/license/MithunWijayasiri/claudecode-statusline" alt="license">
+    <img src="https://img.shields.io/github/license/MithunWijayasiri/ctxline-claude" alt="license">
   </a>
-  <a href="https://github.com/MithunWijayasiri/claudecode-statusline/stargazers">
-    <img src="https://img.shields.io/github/stars/MithunWijayasiri/claudecode-statusline" alt="stars">
+  <a href="https://github.com/MithunWijayasiri/ctxline-claude/stargazers">
+    <img src="https://img.shields.io/github/stars/MithunWijayasiri/ctxline-claude" alt="stars">
   </a>
 </p>
 
@@ -43,8 +43,8 @@ Then restart Claude Code or start a new session. That's it.
 **Clone & run the installer:**
 
 ```bash
-git clone https://github.com/MithunWijayasiri/claudecode-statusline.git
-cd claudecode-statusline
+git clone https://github.com/MithunWijayasiri/ctxline-claude.git
+cd ctxline-claude
 ./install.sh      # macOS / Linux
 ./install.ps1     # Windows (PowerShell)
 ```
@@ -52,7 +52,7 @@ cd claudecode-statusline
 **Manual:** download the script, then point `~/.claude/settings.json` at it.
 
 ```bash
-curl -o ~/.claude/hooks/statusline.js https://raw.githubusercontent.com/MithunWijayasiri/claudecode-statusline/main/statusline.js
+curl -o ~/.claude/hooks/statusline.js https://raw.githubusercontent.com/MithunWijayasiri/ctxline-claude/main/statusline.js
 chmod +x ~/.claude/hooks/statusline.js
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
 <meta property="og:type" content="website">
 <meta property="og:title" content="Claude Code Statusline">
 <meta property="og:description" content="Everything that matters, on one line. Context usage, session limits, and weekly allowance — live, inside Claude Code.">
-<meta property="og:url" content="https://mithunwijayasiri.github.io/claudecode-statusline/">
+<meta property="og:url" content="https://mithunwijayasiri.github.io/ctxline-claude/">
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -284,7 +284,7 @@
       <a href="#install">Install</a>
       <a href="#how">How it works</a>
       <a href="https://www.npmjs.com/package/ctxline-claude" target="_blank" rel="noopener">More info ↗</a>
-      <a href="https://github.com/MithunWijayasiri/claudecode-statusline">GitHub ↗</a>
+      <a href="https://github.com/MithunWijayasiri/ctxline-claude">GitHub ↗</a>
     </div>
   </nav>
 
@@ -367,8 +367,8 @@
     <div class="l">Built for <b>Claude Code</b> · MIT </div>
     <div class="r">
       <a href="https://www.npmjs.com/package/ctxline-claude">npm ↗</a>
-      <a href="https://github.com/MithunWijayasiri/claudecode-statusline">GitHub ↗</a>
-      <a href="https://github.com/MithunWijayasiri/claudecode-statusline/issues">Issues ↗</a>
+      <a href="https://github.com/MithunWijayasiri/ctxline-claude">GitHub ↗</a>
+      <a href="https://github.com/MithunWijayasiri/ctxline-claude/issues">Issues ↗</a>
     </div>
   </footer>
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# Claude Code Enhanced Statusline - Windows PowerShell Installation Script
+﻿# Claude Code Enhanced Statusline - Windows PowerShell Installation Script
 
 $ErrorActionPreference = "Stop"
 

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 
 $HOOKS_DIR = "$env:USERPROFILE\.claude\hooks"
 $SETTINGS_FILE = "$env:USERPROFILE\.claude\settings.json"
-$REPO_URL = "https://raw.githubusercontent.com/MithunWijayasiri/claudecode-statusline/main"
+$REPO_URL = "https://raw.githubusercontent.com/MithunWijayasiri/ctxline-claude/main"
 
 Write-Host "======================================" -ForegroundColor Cyan
 Write-Host "  Claude Code Statusline Installer" -ForegroundColor Cyan
@@ -84,5 +84,5 @@ Write-Host "To uninstall:"
 Write-Host "  - Remove ~/.claude/hooks/$SCRIPT_NAME"
 Write-Host "  - Remove the 'statusLine' section from ~/.claude/settings.json"
 Write-Host ""
-Write-Host "For help, visit: https://github.com/MithunWijayasiri/claudecode-statusline"
+Write-Host "For help, visit: https://github.com/MithunWijayasiri/ctxline-claude"
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 
 HOOKS_DIR="$HOME/.claude/hooks"
 SETTINGS_FILE="$HOME/.claude/settings.json"
-REPO_URL="https://raw.githubusercontent.com/MithunWijayasiri/claudecode-statusline/main"
+REPO_URL="https://raw.githubusercontent.com/MithunWijayasiri/ctxline-claude/main"
 
 # Colors
 GREEN='\033[0;32m'
@@ -122,5 +122,5 @@ echo "To uninstall:"
 echo "  - Remove ~/.claude/hooks/$SCRIPT_NAME"
 echo "  - Remove the 'statusLine' section from ~/.claude/settings.json"
 echo ""
-echo "For help, visit: https://github.com/MithunWijayasiri/claudecode-statusline"
+echo "For help, visit: https://github.com/MithunWijayasiri/ctxline-claude"
 echo ""

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   ],
   "author": "Mithun Wijayasiri",
   "license": "MIT",
-  "homepage": "https://github.com/MithunWijayasiri/claudecode-statusline#readme",
+  "homepage": "https://github.com/MithunWijayasiri/ctxline-claude#readme",
   "bugs": {
-    "url": "https://github.com/MithunWijayasiri/claudecode-statusline/issues"
+    "url": "https://github.com/MithunWijayasiri/ctxline-claude/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MithunWijayasiri/claudecode-statusline.git"
+    "url": "https://github.com/MithunWijayasiri/ctxline-claude.git"
   }
 }

--- a/preview.svg
+++ b/preview.svg
@@ -21,7 +21,7 @@
     <circle cx="60" cy="21" r="6" fill="#61c554"></circle>
 
     
-    <text x="640" y="26" text-anchor="middle" font-size="13" fill="#7d8590" letter-spacing="0.3">claudecode-statusline — zsh — 120×30</text>
+    <text x="640" y="26" text-anchor="middle" font-size="13" fill="#7d8590" letter-spacing="0.3">ctxline-claude — zsh — 120×30</text>
 
     
     <text x="30" y="82" font-size="15" fill="#6e7681"># a configurable statusline for Claude Code</text>

--- a/statusline.js
+++ b/statusline.js
@@ -2,7 +2,7 @@
 // Claude Code Enhanced Statusline
 // Shows: directory | model | context usage | current (5-hour) + weekly usage | current task
 // Auto-detects API key vs subscription usage
-// https://github.com/MithunWijayasiri/claudecode-statusline
+// https://github.com/MithunWijayasiri/ctxline-claude
 
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and site documentation to reference the new ctxline-claude repository and updated site canonical/Open Graph URL and nav/footer links.

* **Chores**
  * Updated installer messages and download links, package metadata URLs, and header/reference comments to point to the ctxline-claude repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->