### PR TITLE
feat: implement compact statusline labels for context and usage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -124,6 +124,7 @@
   .term .dim{color:var(--term-dim)}
   .term .lbl{color:#a7a191}
   .term .pct{font-weight:700}
+  .term .val{color:var(--green);font-weight:700}
   .bar{display:inline-flex;gap:2px;vertical-align:middle;margin:0 7px 0 5px}
   .bar i{width:6px;height:12px;border-radius:1.5px;background:var(--green-dim);display:inline-block}
   .bar i.on{background:var(--green)}
@@ -311,17 +312,12 @@
         <span class="sep">│</span>
         <span>Opus&nbsp;4.8&nbsp;(1M)<span class="dim">&nbsp;· high</span></span>
         <span class="sep">│</span>
-        <span class="lbl">CTX</span>
+        <span class="val">C45</span>
         <span class="bar"><i class="on"></i><i class="on"></i><i class="on"></i><i></i><i></i><i></i></span>
-        <span class="pct">45%</span>
         <span class="sep">│</span>
-        <span class="lbl">5h</span>
-        <span class="bar"><i class="on"></i><i></i><i></i><i></i><i></i><i></i></span>
-        <span class="pct">14%</span>&nbsp;<span class="dim">(4h21m)</span>
+        <span class="val">H14</span>&nbsp;<span class="dim">↺ 4h21m</span>
         <span class="sep">│</span>
-        <span class="lbl">7d</span>
-        <span class="bar"><i class="on"></i><i class="on"></i><i></i><i></i><i></i><i></i></span>
-        <span class="pct">31%</span>&nbsp;<span class="dim">(2d14h)</span>
+        <span class="val">W31</span>&nbsp;<span class="dim">↺ 2d14h</span>
       </div>
     </div>
 
@@ -420,13 +416,13 @@
        tok:'<span class="dim">· high</span>'},
       {tag:'CONTEXT', title:'Context bar',     field:'context_window.remaining_percentage',
        desc:'Context-window usage. The bar shifts color as it fills toward the limit.',
-       tok:'<span class="lbl">CTX</span> '+bar(3)+' <span class="pct">45%</span>'},
+       tok:'<span class="val">C45</span> '+bar(3)},
       {tag:'5H',      title:'5-hour session',  field:'rate_limits.five_hour',
        desc:'Live 5-hour session limit with a reset countdown, read straight from your session data.',
-       tok:'<span class="lbl">5h</span> '+bar(1)+' <span class="pct">14%</span> <span class="dim">(4h20m)</span>'},
+       tok:'<span class="val">H14</span> <span class="dim">↺ 4h20m</span>'},
       {tag:'7D',      title:'Weekly allowance',field:'rate_limits.seven_day',
        desc:'Your weekly usage and the time remaining until the weekly reset.',
-       tok:'<span class="lbl">7d</span> '+bar(2)+' <span class="pct">31%</span> <span class="dim">(2d13h)</span>'},
+       tok:'<span class="val">W31</span> <span class="dim">↺ 2d13h</span>'},
       {tag:'TASK',    title:'Current task',    field:'todos/<session>-agent.json',
        desc:'The in-progress to-do surfaces inline whenever there is active work.',
        tok:'<span class="dim">Refactoring usage cache</span>'}

--- a/preview.svg
+++ b/preview.svg
@@ -29,7 +29,7 @@
     <text x="30" y="140" font-size="15"><tspan fill="#7d8590">▸▸ ready · </tspan><tspan fill="#58a6ff">←</tspan><tspan fill="#7d8590"> for agents</tspan></text>
 
     
-    <text x="28" y="323" font-size="14"><tspan fill="#d97757" font-weight="700">my-project</tspan><tspan fill="#7d8590"> ⎇ main</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Opus 4.8 (1M)</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">CTX </tspan><tspan fill="#3fb950">███</tspan><tspan fill="#2d333b">░░░</tspan><tspan fill="#c9d1d9"> 45%</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">5h </tspan><tspan fill="#f0883e">█████</tspan><tspan fill="#2d333b">░</tspan><tspan fill="#f0883e" font-weight="700"> 81%</tspan><tspan fill="#7d8590"> (2h21m)</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">7d </tspan><tspan fill="#3fb950">██</tspan><tspan fill="#2d333b">░░░░</tspan><tspan fill="#c9d1d9"> 31%</tspan><tspan fill="#7d8590"> (2d14h)</tspan></text>
+    <text x="28" y="323" font-size="14"><tspan fill="#d97757" font-weight="700">my-project</tspan><tspan fill="#7d8590"> ⎇ main</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Opus 4.8 (1M)</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">C45 ███</tspan><tspan fill="#2d333b">░░░</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#f0883e">H81</tspan><tspan fill="#7d8590"> ↺ 2h21m</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">W31</tspan><tspan fill="#7d8590"> ↺ 2d14h</tspan></text>
   </g>
 
   

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -69,9 +69,9 @@ const base = {
   model: 'Opus 4.8 (1M context)',
   remaining: 55,             // context 45% used
   current: 14,
-  currentResetsInMin: 261,   // renders ~(4h21m)
+  currentResetsInMin: 261,   // renders "H14 ↺ 4h21m"
   weekly: 31,
-  weeklyResetsInMin: 3720    // renders ~(2d14h)
+  weeklyResetsInMin: 3720    // renders "W31 ↺ 2d14h"
 };
 
 // Primary line (default effort). NOTE: this MUST stay the first printed line —

--- a/statusline.js
+++ b/statusline.js
@@ -109,23 +109,21 @@ function getContextBar(remaining) {
   const filled = Math.round((used / 100) * BAR_WIDTH);
   const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(BAR_WIDTH - filled);
 
-  let coloredBar;
-  if (used < 50) {
-    coloredBar = `${colors.green}${bar} ${used}%${colors.reset}`;
-  } else if (used < 65) {
-    coloredBar = `${colors.yellow}${bar} ${used}%${colors.reset}`;
-  } else if (used < 80) {
-    coloredBar = `${colors.orange}${bar} ${used}%${colors.reset}`;
-  } else {
-    coloredBar = `${colors.blink}${colors.red}${bar} ${used}%${colors.reset}`;
-  }
+  // Context color: green <50 / yellow <65 / orange <80 / blink-red >=80.
+  let color;
+  if (used < 50) color = colors.green;
+  else if (used < 65) color = colors.yellow;
+  else if (used < 80) color = colors.orange;
+  else color = colors.blink + colors.red;
 
-  return coloredBar;
+  // Compact label form: "C<used> <bar>" (e.g. "C45 ███░░░"), colored as a whole.
+  return `${color}C${used} ${bar}${colors.reset}`;
 }
 
-// Render the usage bar from raw data. Called on every read (live or cached) so the
-// reset countdown is always recomputed from resetsAt rather than frozen at fetch time.
-function buildUsageBar(percentage, resetsAt) {
+// Render a compact usage segment from raw data: "<label><pct> ↺ <countdown>"
+// (e.g. "H81 ↺ 2h21m") — no bar. Called on every read (live or cached) so the reset
+// countdown is always recomputed from resetsAt rather than frozen at fetch time.
+function buildUsageBar(label, percentage, resetsAt) {
   let timeStr = '';
   if (resetsAt) {
     const diffMins = Math.max(0, Math.floor((new Date(resetsAt) - new Date()) / 60000));
@@ -137,21 +135,18 @@ function buildUsageBar(percentage, resetsAt) {
     else timeStr = `${mins}m`;
   }
 
-  const filledWidth = Math.max(0, Math.min(BAR_WIDTH, Math.round((percentage / 100) * BAR_WIDTH)));
-  const filled = '█'.repeat(filledWidth);
-  const empty = '░'.repeat(BAR_WIDTH - filledWidth);
   const color = getUsageColor(percentage);
-  const timePart = timeStr ? `${colors.dim} (${timeStr})${colors.reset}` : '';
+  const timePart = timeStr ? `${colors.dim} ↺ ${timeStr}${colors.reset}` : '';
 
-  return `${color}${filled}${empty} ${percentage}%${colors.reset}${timePart}`;
+  return `${color}${label}${percentage}${colors.reset}${timePart}`;
 }
 
-// Build both usage bars from raw entries. Each entry is { percentage, resetsAt } or
-// null/absent. Returns { current, weekly } where each is a rendered bar string or null.
+// Build both usage segments from raw entries. Each entry is { percentage, resetsAt } or
+// null/absent. Returns { current, weekly } where each is a rendered segment string or null.
 function buildUsageBars(fiveHour, weekly) {
   return {
-    current: fiveHour ? buildUsageBar(fiveHour.percentage, fiveHour.resetsAt) : null,
-    weekly: weekly ? buildUsageBar(weekly.percentage, weekly.resetsAt) : null
+    current: fiveHour ? buildUsageBar('H', fiveHour.percentage, fiveHour.resetsAt) : null,
+    weekly: weekly ? buildUsageBar('W', weekly.percentage, weekly.resetsAt) : null
   };
 }
 
@@ -404,10 +399,10 @@ function outputStatus(data, usage) {
     const parts = [];
     parts.push(branch ? `${dirname} ${colors.dim}⎇ ${branch}${colors.reset}` : dirname);
     parts.push(effort ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}` : model);
-    parts.push(`CTX ${contextBar}`);
+    parts.push(contextBar);
 
-    if (usage?.current) parts.push(`5h ${usage.current}`);
-    if (usage?.weekly) parts.push(`7d ${usage.weekly}`);
+    if (usage?.current) parts.push(usage.current);
+    if (usage?.weekly) parts.push(usage.weekly);
 
     if (task) parts.push(`${colors.dim}${task}${colors.reset}`);
     process.stdout.write(parts.join(' \u2502 '));
@@ -418,9 +413,9 @@ function outputStatus(data, usage) {
 
 function outputFallback(usage) {
   const contextBar = getContextBar(undefined);
-  const parts = ['~', 'Claude', `CTX ${contextBar}`];
-  if (usage?.current) parts.push(`5h ${usage.current}`);
-  if (usage?.weekly) parts.push(`7d ${usage.weekly}`);
+  const parts = ['~', 'Claude', contextBar];
+  if (usage?.current) parts.push(usage.current);
+  if (usage?.weekly) parts.push(usage.weekly);
   process.stdout.write(parts.join(' \u2502 '));
 }
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -106,7 +106,7 @@ test('line assembly: dir basename | model | context, separated by │', () => {
   const parts = clean.split(' │ ');
   assert.strictEqual(parts[0], 'cool-project');        // basename only
   assert.strictEqual(parts[1], 'Sonnet 4.6');          // model passes through
-  assert.match(parts[2], /^CTX /);
+  assert.match(parts[2], /^C\d+ /);                    // compact context label "C60 ███░░░"
 });
 
 test('model name is shortened: "(1M context)" -> "(1M)"', () => {
@@ -201,7 +201,7 @@ test('effort = xhigh is dim (not highlighted red/purple)', () => {
 
 test('context bar shows used% = 100 - remaining', () => {
   const { clean } = run(fixture(65));
-  assert.match(clean, /CTX .* 35%/);              // remaining 65 -> used 35
+  assert.match(clean, /C35 /);                    // remaining 65 -> used 35 -> "C35 <bar>"
 });
 
 test('threshold: used < 50 is green', () => {
@@ -223,7 +223,7 @@ test('threshold: used >= 80 is blinking red, no emoji', () => {
   const { raw, clean } = run(fixture(10));             // used 90
   assert.ok(raw.includes(BLINK) && raw.includes(RED), 'expected blink + red');
   assert.ok(!clean.includes('\u{1F480}'), 'skull emoji should be removed');
-  assert.match(clean, / 90%/);
+  assert.match(clean, /C90 /);
 });
 
 // The contract that must never break: always print, always exit 0.
@@ -231,20 +231,20 @@ test('empty stdin -> fallback line, exit 0', () => {
   const { code, clean } = run('');
   assert.strictEqual(code, 0);
   assert.ok(clean.includes('│'), 'expected a separator in fallback');
-  assert.ok(clean.includes('CTX'), 'expected context label in fallback');
+  assert.match(clean, /C\d+ /, 'expected context label in fallback');
 });
 
 test('malformed JSON -> fallback line, exit 0', () => {
   const { code, clean } = run('not json at all');
   assert.strictEqual(code, 0);
-  assert.ok(clean.includes('CTX'));
+  assert.match(clean, /C\d+ /);
 });
 
 test('missing fields -> no crash, exit 0', () => {
   const { code, clean } = run('{}');
   assert.strictEqual(code, 0);
   assert.ok(clean.includes('Claude'));                 // default model name
-  assert.ok(clean.includes('CTX'));
+  assert.match(clean, /C\d+ /);
 });
 
 // Usage bar: cache-first behavior and the stale fallback that fixes the
@@ -254,24 +254,24 @@ test('fresh cache -> current + weekly rendered from cache (no API call)', () => 
   const home = seedHome({ cacheAgeMs: 5000, percentage: 42, weeklyPercentage: 31 }); // < FRESH_TTL (30s)
   const { code, clean } = run(fixture(40), { home, usage: true });
   assert.strictEqual(code, 0);
-  assert.match(clean, /5h .* 42%/);
-  assert.match(clean, /7d .* 31%/);
-  assert.match(clean, /7d .* 31% \(2d\d{1,2}h\)/);             // day-aware reset countdown (Xd Yh)
+  assert.match(clean, /H42\b/);
+  assert.match(clean, /W31\b/);
+  assert.match(clean, /W31 ↺ 2d\d{1,2}h/);                    // day-aware reset countdown (Xd Yh)
 });
 
 test('stale cache + failing API -> usage stays visible (does not disappear)', () => {
   const home = seedHome({ cacheAgeMs: 2 * 60 * 1000, percentage: 57 }); // > FRESH, < STALE
   const { clean } = run(fixture(40), { home, usage: true });
-  assert.match(clean, /5h .* 57%/);
+  assert.match(clean, /H57\b/);
 });
 
 test('expired cache + failing API -> usage omitted', () => {
   const home = seedHome({ cacheAgeMs: 20 * 60 * 1000, percentage: 57 }); // > STALE_TTL (10m)
   const { code, clean } = run(fixture(40), { home, usage: true });
   assert.strictEqual(code, 0);                                  // ran successfully
-  assert.ok(clean.includes('CTX'), 'expected the normal line to still render');
-  assert.ok(!clean.includes('5h '), 'current usage should be omitted once cache is too old');
-  assert.ok(!clean.includes('7d '), 'weekly usage should be omitted once cache is too old');
+  assert.match(clean, /C\d+ /, 'expected the normal line to still render');
+  assert.ok(!clean.includes('↺'), 'usage (and its reset glyph) should be omitted once cache is too old');
+  assert.ok(!clean.includes('H57'), 'current usage should be omitted once cache is too old');
 });
 
 // Usage from stdin `rate_limits`: the network/cache path is bypassed entirely.
@@ -281,15 +281,15 @@ test('stdin rate_limits -> 5h/7d render with no cache and no creds', () => {
   // can render is straight from stdin rate_limits (proves the API/cache path is skipped).
   const { code, clean } = run(fixtureWithRateLimits(40), { usage: true });
   assert.strictEqual(code, 0);
-  assert.match(clean, /5h .* 24%/);                             // 23.5 -> 24 (fractional, rounded)
-  assert.match(clean, /7d .* 41%/);                             // 41.2 -> 41
-  assert.match(clean, /7d .* 41% \(2d\d{1,2}h\)/);              // epoch-seconds -> day-aware countdown
+  assert.match(clean, /H24\b/);                                 // 23.5 -> 24 (fractional, rounded)
+  assert.match(clean, /W41\b/);                                 // 41.2 -> 41
+  assert.match(clean, /W41 ↺ 2d\d{1,2}h/);                      // epoch-seconds -> day-aware countdown
 });
 
 test('stdin rate_limits takes precedence over a fresh cache', () => {
   // Fresh cache says 42% / 31%; stdin says 23.5% / 41.2%. stdin must win (cache not read).
   const home = seedHome({ cacheAgeMs: 5000, percentage: 42, weeklyPercentage: 31 });
   const { clean } = run(fixtureWithRateLimits(40), { home, usage: true });
-  assert.match(clean, /5h .* 24%/);
-  assert.ok(!clean.includes('42%'), 'cached 5h value must not appear when stdin rate_limits is present');
+  assert.match(clean, /H24\b/);
+  assert.ok(!clean.includes('H42'), 'cached 5h value must not appear when stdin rate_limits is present');
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -222,7 +222,7 @@ test('threshold: 65 <= used < 80 is orange', () => {
 test('threshold: used >= 80 is blinking red, no emoji', () => {
   const { raw, clean } = run(fixture(10));             // used 90
   assert.ok(raw.includes(BLINK) && raw.includes(RED), 'expected blink + red');
-  assert.ok(!clean.includes('\u{1F480}'), 'skull emoji should be removed');
+  assert.ok(!clean.includes('\u{1F480}'), 'skull emoji should not be present');
   assert.match(clean, /C90 /);
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated status display format to use compact notation: `C<value>` for context, `H<value>` for hourly usage, and `W<value>` for weekly usage.
  * Added reset countdown indicators (`↺`) to usage metrics.
  * Applied green accent styling to value labels.

* **Tests**
  * Updated test assertions to reflect new status display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->