### PR TITLE
feat: responsive two-line statusline on narrow terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 > [!NOTE]
 > Usage bars change color automatically as you approach your limits.
 
+> [!NOTE]
+> **Responsive.** On a narrow terminal the line wraps to two — directory, model, and context on the first line; usage, cost, and task on the second. Wide terminals stay on a single line. (Auto-sizing needs Claude Code v2.1.153+.)
+
 ## How it works
 
 - **Source** — context comes from Claude Code's session data. Usage bars are read straight from the `rate_limits` field Claude Code pipes in (no network), falling back to `https://api.anthropic.com/api/oauth/usage` (the same `/usage` data — 5-hour and weekly limits) when that field isn't present yet. API-key users skip usage entirely.

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,7 +341,7 @@
     <div class="sec-head">
       <span class="kicker">What it shows</span>
       <h2>Nine signals, one line</h2>
-      <p>Read left to right, it's the whole picture. Everything is best-effort and silent — if a source is missing, the line just skips it and still renders.</p>
+      <p>Read left to right, it's the whole picture. Everything is best-effort and silent — if a source is missing, the line just skips it and still renders. On a narrow terminal it wraps to a second line; widen, and it returns to one.</p>
     </div>
     <div class="inspect">
       <div class="term"><div class="line insp-line" id="insp-line" role="tablist" aria-label="Statusline segments"></div></div>

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -14,7 +14,7 @@ const SCRIPT = path.join(__dirname, '..', 'statusline.js');
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-preview-'));
 process.on('exit', () => fs.rmSync(TMP, { recursive: true, force: true }));
 
-function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort, rateLimits, cost }) {
+function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort, rateLimits, cost, columns }) {
   const home = fs.mkdtempSync(path.join(TMP, 'home-'));
   const cacheDir = path.join(home, '.claude', 'cache');
   fs.mkdirSync(cacheDir, { recursive: true });
@@ -39,6 +39,10 @@ function render({ dir, model, remaining, current, currentResetsInMin, weekly, we
 
   const env = { ...process.env, HOME: home, USERPROFILE: home };
   delete env.ANTHROPIC_API_KEY;                             // let the usage path run
+  // Width drives the responsive wrap. Force it per-scenario so output is deterministic
+  // regardless of the terminal running preview (and the primary line never wraps).
+  if (columns != null) env.COLUMNS = String(columns);
+  else delete env.COLUMNS;
 
   const res = spawnSync(process.execPath, [SCRIPT], {
     input: JSON.stringify({
@@ -86,6 +90,11 @@ console.log('\nThinking-effort levels:');
 for (const effort of ['xhigh', 'max', 'ultracode']) {
   console.log(`  ${effort.padEnd(9)} ${render({ ...base, effort })}`);
 }
+
+// Responsive: on a narrow terminal the usage/cost/task segments wrap to a second line
+// (width measured against COLUMNS). Wide terminals keep the single line above.
+console.log('\nResponsive (narrow terminal, COLUMNS=40):');
+console.log(render({ ...base, effort: 'high', columns: 40 }));
 
 // Usage from stdin `rate_limits` (Pro/Max post-first-response): no cache, no creds.
 // resets_at is a Unix epoch in seconds. Renders the same 5h/7d bars as the cache path.

--- a/statusline.js
+++ b/statusline.js
@@ -19,6 +19,14 @@ const BAR_WIDTH = 6;
 // Tail-truncation keeps the start (ticket IDs like "TAMA5-32796" live there) visible.
 const MAX_BRANCH_LEN = 24;
 
+// Separator between segments on a rendered line.
+const SEGMENT_SEP = ' │ ';
+
+// Cells reserved at the terminal edge when deciding to wrap to a second line.
+// 0 = use the full COLUMNS; bump it if Claude Code reserves columns and the line
+// truncates a char or two before wrapping.
+const WIDTH_MARGIN = 0;
+
 // Cache configuration
 const CACHE_DIR = path.join(os.homedir(), '.claude', 'cache');
 const USAGE_CACHE_FILE = path.join(CACHE_DIR, 'usage-cache.json');
@@ -392,6 +400,25 @@ function getCurrentTask(sessionId) {
   return '';
 }
 
+// Visible (printable) width of a segment string: strip ANSI color codes, count code points.
+function visibleWidth(str) {
+  return [...str.replace(/\x1b\[[0-9;]*m/g, '')].length;
+}
+
+// Responsive layout: one line when it fits the terminal, else line1 (identity + context)
+// on top and line2 (usage/cost/task) below. Splits only when COLUMNS is known (Claude Code
+// v2.1.153+) and the single line overflows — unknown width or an empty line2 stays single,
+// so there is no regression on older clients or wide terminals.
+function layout(line1Parts, line2Parts) {
+  const single = [...line1Parts, ...line2Parts].join(SEGMENT_SEP);
+  if (line2Parts.length === 0) return single;
+  const cols = parseInt(process.env.COLUMNS, 10);
+  if (Number.isFinite(cols) && cols > 0 && visibleWidth(single) > cols - WIDTH_MARGIN) {
+    return line1Parts.join(SEGMENT_SEP) + '\n' + line2Parts.join(SEGMENT_SEP);
+  }
+  return single;
+}
+
 // Main
 function outputStatus(data, usage) {
   try {
@@ -406,17 +433,20 @@ function outputStatus(data, usage) {
     const contextBar = getContextBar(remaining);
     const cost = getCostSegment(data);
     const task = getCurrentTask(sessionId);
-    const parts = [];
-    parts.push(branch ? `${dirname} ${colors.dim}⎇ ${branch}${colors.reset}` : dirname);
-    parts.push(effort ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}` : model);
-    parts.push(contextBar);
 
-    if (usage?.current) parts.push(usage.current);
-    if (usage?.weekly) parts.push(usage.weekly);
+    // line1 = identity + context (always); line2 = usage/cost/task (wrap target).
+    const line1 = [];
+    line1.push(branch ? `${dirname} ${colors.dim}⎇ ${branch}${colors.reset}` : dirname);
+    line1.push(effort ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}` : model);
+    line1.push(contextBar);
 
-    if (cost) parts.push(cost);
-    if (task) parts.push(`${colors.dim}${task}${colors.reset}`);
-    process.stdout.write(parts.join(' \u2502 '));
+    const line2 = [];
+    if (usage?.current) line2.push(usage.current);
+    if (usage?.weekly) line2.push(usage.weekly);
+    if (cost) line2.push(cost);
+    if (task) line2.push(`${colors.dim}${task}${colors.reset}`);
+
+    process.stdout.write(layout(line1, line2));
   } catch (e) {
     process.stdout.write('Status unavailable');
   }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -27,6 +27,13 @@ function run(input, opts = {}) {
   } else {
     env.ANTHROPIC_API_KEY = 'test';
   }
+  // Width drives the responsive wrap. Default: unset -> always single line (matches
+  // pre-responsive behavior, keeps `split(' │ ')` assertions deterministic).
+  if (opts.columns != null) {
+    env.COLUMNS = String(opts.columns);
+  } else {
+    delete env.COLUMNS;
+  }
   const res = spawnSync(process.execPath, [SCRIPT], { input, encoding: 'utf8', timeout: 5000, env });
   const raw = res.stdout || '';
   const clean = raw.replace(/\x1b\[[0-9;]*m/g, ''); // strip ANSI for readable assertions
@@ -319,4 +326,54 @@ test('stdin rate_limits takes precedence over a fresh cache', () => {
   const { clean } = run(fixtureWithRateLimits(40), { home, usage: true });
   assert.match(clean, /H24\b/);
   assert.ok(!clean.includes('H42'), 'cached 5h value must not appear when stdin rate_limits is present');
+});
+
+// Responsive layout: usage/cost/task wrap to a second line only when the rendered line
+// overflows the terminal width (process.env.COLUMNS). Width unknown or line fits -> single.
+
+test('narrow terminal wraps usage to a second line (line1 identity+context, line2 usage)', () => {
+  const { code, raw, clean } = run(fixtureWithRateLimits(40), { usage: true, columns: 30 });
+  assert.strictEqual(code, 0);
+  assert.ok(raw.includes('\n'), 'expected a line break on a narrow terminal');
+  const [l1, l2] = clean.split('\n');
+  assert.match(l1, /C\d+ /, 'context stays on line 1');
+  assert.ok(!/[HW]\d+/.test(l1), 'usage must not be on line 1 when wrapped');
+  assert.match(l2, /H\d+\b/, 'current usage moves to line 2');
+  assert.match(l2, /W\d+\b/, 'weekly usage moves to line 2');
+});
+
+test('wide terminal keeps everything on one line', () => {
+  const { raw, clean } = run(fixtureWithRateLimits(40), { usage: true, columns: 200 });
+  assert.ok(!raw.includes('\n'), 'no wrap when the line fits');
+  assert.match(clean, /C\d+ .*H\d+\b.*W\d+\b/, 'context + usage all on one line');
+});
+
+test('unknown width (COLUMNS unset) never wraps', () => {
+  const { raw } = run(fixtureWithRateLimits(40), { usage: true });   // run() deletes COLUMNS
+  assert.ok(!raw.includes('\n'), 'absent COLUMNS -> single line (no regression on old clients)');
+});
+
+test('narrow terminal with no usage/cost/task stays single line', () => {
+  // Only identity + context exist (no rate_limits, API-key path skips usage) -> nothing to wrap.
+  const { raw } = run(fixture(40, '/no/such/repo', 'Opus 4.8'), { columns: 10 });
+  assert.ok(!raw.includes('\n'), 'empty line2 -> single line regardless of width');
+});
+
+test('narrow wrap puts cost on line 2 alongside usage', () => {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const input = JSON.stringify({
+    model: { display_name: 'Opus 4.8' },
+    workspace: { current_dir: '/tmp/myproject' },
+    session_id: 'test-session',
+    context_window: { remaining_percentage: 40 },
+    cost: { total_cost_usd: 1.23 },
+    rate_limits: {
+      five_hour: { used_percentage: 23.5, resets_at: nowSec + 2 * 3600 },
+      seven_day: { used_percentage: 41.2, resets_at: nowSec + 62 * 3600 }
+    }
+  });
+  const { clean } = run(input, { usage: true, columns: 30 });
+  const [l1, l2] = clean.split('\n');
+  assert.ok(!l1.includes('$1.23'), 'cost must not be on line 1');
+  assert.match(l2, /\$1\.23\b/, 'cost wraps to line 2');
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline now adapts responsively to terminal width, wrapping to two lines on narrow terminals while maintaining single-line format on wider displays.

* **Documentation**
  * Updated README and documentation to describe responsive statusline behavior and minimum version requirements.

* **Tests**
  * Added test coverage for responsive layout functionality across various terminal widths and content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->