### PR TITLE
feat: show git ahead/behind vs upstream in branch segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 | Segment | Detail |
 |---|---|
 | **Directory** | Current working directory |
+| **Branch** | Active git branch, with `↑N↓M` commits ahead / behind your upstream when it diverges |
 | **Model** | Active Claude model (Opus / Sonnet / Haiku) |
 | **Context** | Visual bar of context-window usage |
 | **Current** | Live 5-hour session limit + reset countdown (subscription users) |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 ## FAQ
 
 <details>
+<summary>Does it use extra tokens?</summary>
+
+No — zero tokens, ever. The statusline is part of Claude Code's UI; its output is drawn in your terminal and is **never sent to the model**. Nothing it shows (context, usage, cost, git status) enters the conversation or counts toward your context window.
+
+</details>
+
+<details>
+<summary>Does fetching data slow down Claude Code?</summary>
+
+No, it's imperceptible. Almost every render reads a small local cache (sub-millisecond) instead of fetching. The usage API only runs as a fallback (and is cached); the git ahead/behind check runs at most once every ~5s and is hard-capped so it can never hang. The statusline runs as its own background command, so it never blocks your typing or Claude's responses — and in a non-git folder the git check doesn't run at all.
+
+</details>
+
+<details>
 <summary>Does this use the same data as /usage?</summary>
 
 Yes — the same 5-hour and weekly limits. It reads them from the session data Claude Code provides when available, and falls back to Anthropic's usage API (the endpoint `/usage` uses) otherwise.

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,6 +125,8 @@
   .term .lbl{color:#a7a191}
   .term .pct{font-weight:700}
   .term .val{color:var(--green);font-weight:700}
+  .term .ahead{color:var(--green);font-weight:700}
+  .term .behind{color:#f85149;font-weight:700}
   .bar{display:inline-flex;gap:2px;vertical-align:middle;margin:0 7px 0 5px}
   .bar i{width:6px;height:12px;border-radius:1.5px;background:var(--green-dim);display:inline-block}
   .bar i.on{background:var(--green)}
@@ -308,7 +310,7 @@
 
     <div class="term" aria-label="Example statusline">
       <div class="line">
-        <span class="proj">my-project</span>&nbsp;<span class="dim">⎇ main</span>
+        <span class="proj">my-project</span>&nbsp;<span class="dim">⎇ main</span>&nbsp;<span class="ahead">↑2</span><span class="behind">↓1</span>
         <span class="sep">│</span>
         <span>Opus&nbsp;4.8&nbsp;(1M)<span class="dim">&nbsp;· high</span></span>
         <span class="sep">│</span>
@@ -408,8 +410,8 @@
        desc:'The current working directory — you always know where Claude is operating.',
        tok:'<span class="proj">my-project</span>'},
       {tag:'BRANCH',  title:'Git branch',      field:'.git/HEAD',
-       desc:'Active branch beside the dir, read straight from .git. Long names trim; the ticket ID stays.',
-       tok:'<span class="dim">⎇ main</span>'},
+       desc:'Active branch beside the dir, read straight from .git. Long names trim; the ticket ID stays. Adds ↑N↓M commits ahead/behind your upstream when it diverges.',
+       tok:'<span class="dim">⎇ main</span>&nbsp;<span class="ahead">↑2</span><span class="behind">↓1</span>'},
       {tag:'MODEL',   title:'Active model',    field:'model.display_name',
        desc:'Opus, Sonnet, or Haiku — plus the context window size at a glance.',
        tok:'Opus&nbsp;4.8&nbsp;(1M)'},

--- a/preview.svg
+++ b/preview.svg
@@ -29,7 +29,7 @@
     <text x="30" y="140" font-size="15"><tspan fill="#7d8590">▸▸ ready · </tspan><tspan fill="#58a6ff">←</tspan><tspan fill="#7d8590"> for agents</tspan></text>
 
     
-    <text x="28" y="323" font-size="14"><tspan fill="#d97757" font-weight="700">my-project</tspan><tspan fill="#7d8590"> ⎇ main</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Opus 4.8 (1M)</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">C45 ███</tspan><tspan fill="#2d333b">░░░</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#f0883e">H81</tspan><tspan fill="#7d8590"> ↺ 2h21m</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">W31</tspan><tspan fill="#7d8590"> ↺ 2d14h</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">$44.21</tspan></text>
+    <text x="28" y="323" font-size="14"><tspan fill="#d97757" font-weight="700">my-project</tspan><tspan fill="#7d8590"> ⎇ main </tspan><tspan fill="#3fb950">↑2</tspan><tspan fill="#f85149">↓1</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Opus 4.8 (1M)</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">C45 ███</tspan><tspan fill="#2d333b">░░░</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#f0883e">H81</tspan><tspan fill="#7d8590"> ↺ 2h21m</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">W31</tspan><tspan fill="#7d8590"> ↺ 2d14h</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">$44.21</tspan></text>
   </g>
 
   

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -12,9 +12,40 @@ const path = require('node:path');
 
 const SCRIPT = path.join(__dirname, '..', 'statusline.js');
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-preview-'));
-process.on('exit', () => fs.rmSync(TMP, { recursive: true, force: true }));
+process.on('exit', () => fs.rmSync(TMP, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
 
-function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort, rateLimits, cost, columns }) {
+// Build a real diverged git repo in `projectDir` so statusline.js renders ↑N↓M.
+// Best-effort: returns true on success, false if git is unavailable (caller falls back
+// to a fake .git/HEAD so the line — and the release body — still render).
+function setupDivergedRepo(projectDir, branch) {
+  try {
+    const g = (args) => spawnSync('git', args, { cwd: projectDir, encoding: 'utf8' });
+    fs.mkdirSync(projectDir, { recursive: true });
+    if (g(['init', '-q']).status !== 0) return false;
+    const commit = (tag) => {
+      fs.writeFileSync(path.join(projectDir, 'f-' + tag), tag);
+      g(['add', '-A']); g(['commit', '-q', '-m', tag]);
+    };
+    g(['config', 'user.email', 't@t']); g(['config', 'user.name', 'preview']);
+    g(['config', 'commit.gpgsign', 'false']);
+    g(['config', 'remote.origin.url', '.']);
+    g(['config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*']);
+    commit('base');
+    g(['branch', '-M', branch]);                              // force the displayed branch name
+    const baseSha = g(['rev-parse', 'HEAD']).stdout.trim();
+    commit('up0');                                            // upstream +1 -> behind 1
+    g(['update-ref', 'refs/remotes/origin/' + branch, g(['rev-parse', 'HEAD']).stdout.trim()]);
+    g(['config', 'branch.' + branch + '.remote', 'origin']);
+    g(['config', 'branch.' + branch + '.merge', 'refs/heads/' + branch]);
+    g(['reset', '--hard', '-q', baseSha]);
+    commit('local0'); commit('local1');                      // local +2 -> ahead 2
+    return g(['rev-parse', '--git-dir']).status === 0;
+  } catch (e) {
+    return false;
+  }
+}
+
+function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort, rateLimits, cost, columns, diverged }) {
   const home = fs.mkdtempSync(path.join(TMP, 'home-'));
   const cacheDir = path.join(home, '.claude', 'cache');
   fs.mkdirSync(cacheDir, { recursive: true });
@@ -31,11 +62,14 @@ function render({ dir, model, remaining, current, currentResetsInMin, weekly, we
     }));
   }
 
-  // Real on-disk dir with a seeded .git/HEAD so the branch segment renders (statusline.js
-  // reads .git/HEAD directly). basename(currentDir) keeps the displayed dir name.
+  // Real on-disk dir so the branch segment renders. `diverged` builds a real repo with an
+  // upstream (for ↑N↓M); otherwise (or if git is missing) seed a fake .git/HEAD — statusline.js
+  // reads it directly. basename(currentDir) keeps the displayed dir name.
   const projectDir = path.join(home, dir);
-  fs.mkdirSync(path.join(projectDir, '.git'), { recursive: true });
-  fs.writeFileSync(path.join(projectDir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
+  if (!(diverged && setupDivergedRepo(projectDir, branch))) {
+    fs.mkdirSync(path.join(projectDir, '.git'), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
+  }
 
   const env = { ...process.env, HOME: home, USERPROFILE: home };
   delete env.ANTHROPIC_API_KEY;                             // let the usage path run
@@ -82,7 +116,8 @@ const base = {
 
 // Primary line (default effort). NOTE: this MUST stay the first printed line —
 // the release workflow takes only line 1 (`head -n 1`) for the GitHub release body.
-console.log(render({ ...base, effort: 'high' }));
+// `diverged` shows ↑N↓M from a real upstream; falls back to no-counts if git is missing.
+console.log(render({ ...base, effort: 'high', diverged: true }));
 
 // Thinking-effort color variants: only the top two levels are highlighted.
 // (low < medium < high < xhigh < max < ultracode; xhigh stays dim, max red, ultracode purple.)

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -34,7 +34,8 @@ function setupDivergedRepo(projectDir, branch) {
     g(['branch', '-M', branch]);                              // force the displayed branch name
     const baseSha = g(['rev-parse', 'HEAD']).stdout.trim();
     commit('up0');                                            // upstream +1 -> behind 1
-    g(['update-ref', 'refs/remotes/origin/' + branch, g(['rev-parse', 'HEAD']).stdout.trim()]);
+    const upstreamSha = g(['rev-parse', 'HEAD']).stdout.trim();
+    g(['update-ref', 'refs/remotes/origin/' + branch, upstreamSha]);
     g(['config', 'branch.' + branch + '.remote', 'origin']);
     g(['config', 'branch.' + branch + '.merge', 'refs/heads/' + branch]);
     g(['reset', '--hard', '-q', baseSha]);

--- a/statusline.js
+++ b/statusline.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const https = require('https');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const IS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
 
@@ -35,6 +35,13 @@ const FRESH_TTL_MS = 30000;            // 30 seconds
 // Stale: used only as a fallback when a live API call fails, so the usage bar stays
 // visible through transient timeouts/errors instead of disappearing.
 const STALE_TTL_MS = 10 * 60 * 1000;   // 10 minutes
+
+// Git ahead/behind cache (single repo entry, keyed by git dir). Throttles the one
+// `git rev-list` subprocess so a burst of renders in a turn runs it once, not per render.
+const GIT_CACHE_FILE = path.join(CACHE_DIR, 'git-cache.json');
+const GIT_FRESH_TTL_MS = 5000;          // 5s: reuse counts within a render burst
+const GIT_STALE_TTL_MS = 60000;         // 60s: fall back to last counts if git fails
+const GIT_TIMEOUT_MS = 500;             // hard cap on the rev-list subprocess (warm ~130ms)
 
 // ANSI color codes
 const colors = {
@@ -76,30 +83,35 @@ function truncateBranch(name) {
   return name.length > MAX_BRANCH_LEN ? name.slice(0, MAX_BRANCH_LEN - 1) + '…' : name;
 }
 
-// Resolve the current git branch by reading .git/HEAD directly (no `git` subprocess —
-// keeps the render fast and dependency-free). Walks up from `dir` to find the repo,
-// handles worktrees (.git as a file) and detached HEAD (short sha). Best-effort: '' on any failure.
+// Resolve the repo's git dir by walking up from `dir` (no `git` subprocess). Handles
+// worktrees/submodules (".git" as a file pointing at the real dir). '' on any failure.
+function resolveGitDir(dir) {
+  let cur = dir;
+  let gitPath = '';
+  for (let i = 0; i < 50 && cur; i++) {
+    const candidate = path.join(cur, '.git');
+    if (fs.existsSync(candidate)) { gitPath = candidate; break; }
+    const parent = path.dirname(cur);
+    if (parent === cur) break;          // reached filesystem root
+    cur = parent;
+  }
+  if (!gitPath) return '';
+
+  if (fs.statSync(gitPath).isFile()) {
+    // ".git" is a file like "gitdir: /path/to/.git/worktrees/x".
+    const m = fs.readFileSync(gitPath, 'utf8').match(/gitdir:\s*(.+)/);
+    if (!m) return '';
+    return path.resolve(path.dirname(gitPath), m[1].trim());
+  }
+  return gitPath;
+}
+
+// Current git branch, read straight from .git/HEAD (no `git` subprocess — fast,
+// dependency-free). Detached HEAD -> short sha. Best-effort: '' on any failure.
 function getGitBranch(dir) {
   try {
-    let cur = dir;
-    let gitPath = '';
-    for (let i = 0; i < 50 && cur; i++) {
-      const candidate = path.join(cur, '.git');
-      if (fs.existsSync(candidate)) { gitPath = candidate; break; }
-      const parent = path.dirname(cur);
-      if (parent === cur) break;        // reached filesystem root
-      cur = parent;
-    }
-    if (!gitPath) return '';
-
-    let gitDir = gitPath;
-    if (fs.statSync(gitPath).isFile()) {
-      // Worktree/submodule: ".git" is a file like "gitdir: /path/to/.git/worktrees/x".
-      const m = fs.readFileSync(gitPath, 'utf8').match(/gitdir:\s*(.+)/);
-      if (!m) return '';
-      gitDir = path.resolve(path.dirname(gitPath), m[1].trim());
-    }
-
+    const gitDir = resolveGitDir(dir);
+    if (!gitDir) return '';
     const head = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
     const ref = head.match(/^ref:\s*refs\/heads\/(.+)$/);
     if (ref) return truncateBranch(ref[1]);
@@ -108,6 +120,72 @@ function getGitBranch(dir) {
   } catch (e) {
     return '';
   }
+}
+
+// Read the cached ahead/behind for `gitDir`. Single-entry file: a different repo
+// invalidates it. Returns { age, ahead, behind } or null.
+function readGitCache(gitDir) {
+  try {
+    const c = JSON.parse(fs.readFileSync(GIT_CACHE_FILE, 'utf8'));
+    if (!c || c.gitDir !== gitDir || !Number.isFinite(c.timestamp)) return null;
+    if (!Number.isFinite(c.ahead) || !Number.isFinite(c.behind)) return null;
+    return { age: Date.now() - c.timestamp, ahead: c.ahead, behind: c.behind };
+  } catch (e) {
+    return null;
+  }
+}
+
+function writeGitCache(gitDir, ahead, behind) {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
+    fs.writeFileSync(GIT_CACHE_FILE, JSON.stringify({ gitDir, timestamp: Date.now(), ahead, behind }), 'utf8');
+  } catch (e) {}
+}
+
+// Commits ahead/behind the upstream (@{u}), cache-fronted. The single `git` call in the
+// whole script — gated by GIT_FRESH_TTL_MS so a render burst runs it once. No upstream /
+// detached / no git -> the subprocess errors -> null (segment omitted). On a slow/failed
+// call, falls back to the last counts up to GIT_STALE_TTL_MS so they don't flicker.
+function getGitAheadBehind(dir) {
+  const gitDir = resolveGitDir(dir);
+  if (!gitDir) return null;
+
+  const cached = readGitCache(gitDir);
+  if (cached && cached.age < GIT_FRESH_TTL_MS) {
+    return { ahead: cached.ahead, behind: cached.behind };
+  }
+
+  try {
+    // execFileSync (no shell): faster cold spawn than execSync and passes `@{u}` literally.
+    // `@{u}...HEAD` with --left-right --count prints "<behind>\t<ahead>" (left = upstream).
+    const out = execFileSync('git', ['rev-list', '--left-right', '--count', '@{u}...HEAD'], {
+      cwd: dir, encoding: 'utf8', timeout: GIT_TIMEOUT_MS, stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+    const parts = out.split(/\s+/);
+    const behind = parseInt(parts[0], 10);
+    const ahead = parseInt(parts[1], 10);
+    if (Number.isFinite(ahead) && Number.isFinite(behind)) {
+      writeGitCache(gitDir, ahead, behind);
+      return { ahead, behind };
+    }
+    return null;
+  } catch (e) {
+    if (cached && cached.age < GIT_STALE_TTL_MS) {
+      return { ahead: cached.ahead, behind: cached.behind };
+    }
+    return null;
+  }
+}
+
+// "↑N↓M" from ahead/behind counts: ahead green (commits to push), behind red (missing
+// commits). Each part self-resets so it doesn't inherit the dim branch color. Omit a zero
+// side; '' when in sync or null.
+function formatAheadBehind(ab) {
+  if (!ab) return '';
+  let s = '';
+  if (ab.ahead) s += `${colors.green}↑${ab.ahead}${colors.reset}`;
+  if (ab.behind) s += `${colors.red}↓${ab.behind}${colors.reset}`;
+  return s;
 }
 
 function getContextBar(remaining) {
@@ -426,6 +504,7 @@ function outputStatus(data, usage) {
     const dir = data?.workspace?.current_dir || process.cwd();
     const dirname = path.basename(dir);
     const branch = getGitBranch(dir);
+    const sync = branch ? formatAheadBehind(getGitAheadBehind(dir)) : '';
     const effort = data?.effort?.level || '';
     const sessionId = data?.session_id || '';
     const remaining = data?.context_window?.remaining_percentage;
@@ -436,7 +515,9 @@ function outputStatus(data, usage) {
 
     // line1 = identity + context (always); line2 = usage/cost/task (wrap target).
     const line1 = [];
-    line1.push(branch ? `${dirname} ${colors.dim}⎇ ${branch}${colors.reset}` : dirname);
+    line1.push(branch
+      ? `${dirname} ${colors.dim}⎇ ${branch}${colors.reset}${sync ? ' ' + sync : ''}`
+      : dirname);
     line1.push(effort ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}` : model);
     line1.push(contextBar);
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -13,7 +13,7 @@ const SCRIPT = path.join(__dirname, '..', 'statusline.js');
 
 // Empty fake HOME so the todos/credentials lookups find nothing -> deterministic.
 const FAKE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-test-'));
-after(() => fs.rmSync(FAKE_HOME, { recursive: true, force: true }));
+after(() => fs.rmSync(FAKE_HOME, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
 
 // Run statusline.js with the given stdin string. Returns { code, raw, clean }.
 // opts.home  : override the fake HOME (default: empty FAKE_HOME -> no usage/todos)
@@ -95,8 +95,54 @@ function seedRepo(branch = 'feature/x') {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-repo-'));
   fs.mkdirSync(path.join(dir, '.git'));
   fs.writeFileSync(path.join(dir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
-  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
   return dir;
+}
+
+// --- real-git helpers for the ahead/behind segment ---
+function git(dir, args) { return spawnSync('git', args, { cwd: dir, encoding: 'utf8' }); }
+function hasGit() {
+  const r = spawnSync('git', ['--version'], { encoding: 'utf8' });
+  return r.status === 0;
+}
+function gitCommit(dir, tag) {
+  fs.writeFileSync(path.join(dir, 'f-' + tag), tag);
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', tag]);
+}
+
+// Real git repo whose HEAD is `ahead` commits ahead and `behind` behind a tracked
+// upstream (origin/<branch>), so `git rev-list @{u}...HEAD` reports real counts.
+function seedDivergedRepo({ ahead = 0, behind = 0 } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-gitdiv-'));
+  after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 't@t']);
+  git(dir, ['config', 'user.name', 'test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  // register origin so the merge ref maps to a remote-tracking branch (@{u} resolves)
+  git(dir, ['config', 'remote.origin.url', '.']);
+  git(dir, ['config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*']);
+  gitCommit(dir, 'base');
+  const branch = git(dir, ['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+  const baseSha = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
+  // build the upstream (behind) chain on top of base, park it in origin/<branch>
+  for (let i = 0; i < behind; i++) gitCommit(dir, 'up' + i);
+  const upstreamSha = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
+  git(dir, ['update-ref', 'refs/remotes/origin/' + branch, upstreamSha]);
+  git(dir, ['config', 'branch.' + branch + '.remote', 'origin']);
+  git(dir, ['config', 'branch.' + branch + '.merge', 'refs/heads/' + branch]);
+  // reset HEAD back to base, then build the local (ahead) chain -> diverges from upstream
+  git(dir, ['reset', '--hard', '-q', baseSha]);
+  for (let i = 0; i < ahead; i++) gitCommit(dir, 'local' + i);
+  return dir;
+}
+
+// Throwaway HOME so each git test gets an isolated git-cache.json.
+function freshHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-githome-'));
+  after(() => fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
+  return home;
 }
 
 // ANSI color codes the script emits (kept in sync with statusline.js `colors`).
@@ -158,7 +204,7 @@ test('detached HEAD -> short 7-char SHA', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-detach-'));
   fs.mkdirSync(path.join(dir, '.git'));
   fs.writeFileSync(path.join(dir, '.git', 'HEAD'), 'abc1234567890abcdef1234567890abcdef12345\n'); // 40-char SHA
-  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
   const { clean } = run(fixture(40, dir));
   assert.match(clean.split(' │ ')[0], /⎇ abc1234$/);   // first 7 chars of the SHA
 });
@@ -169,8 +215,8 @@ test('worktree (.git is a file with gitdir:) -> branch still renders', () => {
   fs.writeFileSync(path.join(gitdir, 'HEAD'), 'ref: refs/heads/feature/wt\n');
   fs.writeFileSync(path.join(dir, '.git'), `gitdir: ${gitdir}\n`); // .git as a file pointer
   after(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
-    fs.rmSync(gitdir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    fs.rmSync(gitdir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
   const { clean } = run(fixture(40, dir));
   assert.match(clean.split(' │ ')[0], /⎇ feature\/wt$/);
@@ -376,4 +422,71 @@ test('narrow wrap puts cost on line 2 alongside usage', () => {
   const [l1, l2] = clean.split('\n');
   assert.ok(!l1.includes('$1.23'), 'cost must not be on line 1');
   assert.match(l2, /\$1\.23\b/, 'cost wraps to line 2');
+});
+
+// Git ahead/behind: counts come from a guarded, cache-fronted `git rev-list`. Needs real git.
+
+test('ahead of upstream -> ↑N in the branch segment', (t) => {
+  if (!hasGit()) return t.skip('git not available');
+  const dir = seedDivergedRepo({ ahead: 2 });
+  const { clean } = run(fixture(40, dir), { home: freshHome() });
+  assert.match(clean, /⎇ \S+ ↑2/, 'expected ↑2');
+  assert.ok(!clean.includes('↓'), 'no behind marker when only ahead');
+});
+
+test('behind upstream -> ↓N in the branch segment', (t) => {
+  if (!hasGit()) return t.skip('git not available');
+  const dir = seedDivergedRepo({ behind: 3 });
+  const { clean } = run(fixture(40, dir), { home: freshHome() });
+  assert.match(clean, /⎇ \S+ ↓3/, 'expected ↓3');
+  assert.ok(!clean.includes('↑'), 'no ahead marker when only behind');
+});
+
+test('diverged -> ↑N↓M (ahead then behind)', (t) => {
+  if (!hasGit()) return t.skip('git not available');
+  const dir = seedDivergedRepo({ ahead: 2, behind: 1 });
+  const { clean } = run(fixture(40, dir), { home: freshHome() });
+  assert.match(clean, /⎇ \S+ ↑2↓1/, 'expected ↑2↓1');
+});
+
+test('ahead is green, behind is red', (t) => {
+  if (!hasGit()) return t.skip('git not available');
+  const dir = seedDivergedRepo({ ahead: 2, behind: 1 });
+  const { raw } = run(fixture(40, dir), { home: freshHome() });
+  assert.ok(raw.includes(`${GREEN}↑2`), 'ahead count should be green');
+  assert.ok(raw.includes(`${RED}↓1`), 'behind count should be red');
+});
+
+test('in sync with upstream -> no ahead/behind marker', (t) => {
+  if (!hasGit()) return t.skip('git not available');
+  const dir = seedDivergedRepo({ ahead: 0, behind: 0 });
+  const { clean } = run(fixture(40, dir), { home: freshHome() });
+  assert.match(clean, /⎇ \S+/, 'branch still renders');
+  assert.ok(!clean.includes('↑') && !clean.includes('↓'), 'no marker when in sync');
+});
+
+test('no upstream -> branch renders, no ahead/behind marker', (t) => {
+  if (!hasGit()) return t.skip('git not available');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-noup-'));
+  after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 't@t']);
+  git(dir, ['config', 'user.name', 'test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  gitCommit(dir, 'base');                                  // committed, but no upstream configured
+  const { clean } = run(fixture(40, dir), { home: freshHome() });
+  assert.match(clean, /⎇ \S+/, 'branch renders');
+  assert.ok(!clean.includes('↑') && !clean.includes('↓'), 'no marker without an upstream');
+});
+
+test('counts are cached: a commit within the TTL does not change the rendered count', (t) => {
+  if (!hasGit()) return t.skip('git not available');
+  const home = freshHome();                                // shared across both renders -> shared cache
+  const dir = seedDivergedRepo({ ahead: 1 });
+  const first = run(fixture(40, dir), { home });
+  assert.match(first.clean, /↑1/, 'first render shows ↑1 and writes cache');
+  gitCommit(dir, 'extra');                                 // now actually ↑2
+  const second = run(fixture(40, dir), { home });          // within 5s TTL -> cache hit
+  assert.match(second.clean, /↑1/, 'cached ↑1 reused; git not re-run');
+  assert.ok(!second.clean.includes('↑2'), 'fresh count must not appear within the TTL');
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added branch divergence indicators to statusline, displaying how many commits are ahead/behind the upstream branch using ↑N↓M format.
  * Ahead/behind counts display in green and red respectively.

* **Documentation**
  * Updated README and example statusline to reflect branch divergence feature.

* **Tests**
  * Added tests for branch divergence indicators and upstream sync status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->