### PR TITLE
feat: add CTXLINE_DISABLE to hide statusline segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@
 
 See your **current directory**, **active model**, **context window usage**, and **Claude usage limits** at a glance — including both your **current 5-hour session** and **weekly allowance**.
 
+## Contents
+
+- [Install](#install)
+- [Uninstall](#uninstall)
+- [What it shows](#what-it-shows)
+- [Configuration](#configuration)
+- [How it works](#how-it-works)
+- [FAQ](#faq)
+
 ## Install
 
 ```bash
@@ -120,6 +129,55 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 
 > [!NOTE]
 > **Responsive.** On a narrow terminal the line wraps to two — directory, model, and context on the first line; usage, cost, and task on the second. Wide terminals stay on a single line. (Auto-sizing needs Claude Code v2.1.153+.)
+
+> [!TIP]
+> Don't want every segment? You can hide any of them — see [Configuration](#configuration).
+
+## Configuration
+
+The statusline is zero-config by default. To **hide segments you don't want**, set the `CTXLINE_DISABLE` environment variable to a comma-separated list of any of:
+
+`branch` · `effort` · `cost` · `task` · `usage` (5-hour + weekly)
+
+Directory, model, and context always show; unknown names are ignored. Example below hides cost and the current task.
+
+### Option A — `settings.json` (recommended)
+
+Works on every OS and survives restarts. Add a top-level `env` block to `~/.claude/settings.json` — Claude Code passes it to every command it spawns, including the statusline:
+
+```json
+{
+  "env": {
+    "CTXLINE_DISABLE": "cost,task"
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "node ~/.claude/hooks/statusline.js"
+  }
+}
+```
+
+Restart Claude Code (or start a new session) to apply.
+
+### Option B — shell environment
+
+Set the variable **before** launching `claude` (the statusline inherits Claude Code's environment):
+
+```bash
+# macOS / Linux
+export CTXLINE_DISABLE="cost,task"
+claude
+```
+
+```powershell
+# Windows (PowerShell) — this terminal only
+$env:CTXLINE_DISABLE = "cost,task"; claude
+
+# Windows — persist for future sessions (then open a NEW terminal)
+setx CTXLINE_DISABLE "cost,task"
+```
+
+To re-enable a segment, remove it from the list (or delete the variable) and restart Claude Code.
 
 ## How it works
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -144,6 +144,7 @@
     background:linear-gradient(to right,transparent,var(--term-bg))}
 
   .cta{display:flex;gap:14px;justify-content:center;flex-wrap:wrap;margin-top:40px}
+  .cta-stack{flex-direction:column;align-items:center}
   .btn{
     font-family:var(--mono);font-size:14px;font-weight:500;
     text-decoration:none;border-radius:11px;padding:13px 22px;
@@ -374,9 +375,23 @@
     </div>
   </section>
 
+  <!-- LEARN MORE -->
+  <section class="block">
+    <div class="sec-head">
+      <span class="kicker">Learn more</span>
+      <p>The rest lives in the docs on GitHub — one click away.</p>
+    </div>
+    <div class="cta cta-stack">
+      <a class="btn ghost" href="https://github.com/MithunWijayasiri/ctxline-claude#faq">Got a question? Read the FAQ ↗</a>
+      <a class="btn ghost" href="https://github.com/MithunWijayasiri/ctxline-claude#configuration">Want to customize? Configure it ↗</a>
+    </div>
+  </section>
+
   <footer>
     <div class="l">Built for <b>Claude Code</b> · MIT </div>
     <div class="r">
+      <a href="https://github.com/MithunWijayasiri/ctxline-claude#configuration">Config ↗</a>
+      <a href="https://github.com/MithunWijayasiri/ctxline-claude#faq">FAQ ↗</a>
       <a href="https://www.npmjs.com/package/ctxline-claude">npm ↗</a>
       <a href="https://github.com/MithunWijayasiri/ctxline-claude">GitHub ↗</a>
       <a href="https://github.com/MithunWijayasiri/ctxline-claude/issues">Issues ↗</a>
@@ -432,7 +447,7 @@
        tok:'<span class="dim">$44.21</span>'},
       {tag:'TASK',    title:'Current task',    field:'todos/<session>-agent.json',
        desc:'The in-progress to-do surfaces inline whenever there is active work.',
-       tok:'<span class="dim">Refactoring usage cache</span>'}
+       tok:'<span class="dim">Yak shaving</span>'}
     ];
     var panel=document.getElementById('insp-panel'),
         badge=document.getElementById('insp-badge'), title=document.getElementById('insp-title'),

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -46,7 +46,7 @@ function setupDivergedRepo(projectDir, branch) {
   }
 }
 
-function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort, rateLimits, cost, columns, diverged }) {
+function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, branch, effort, rateLimits, cost, columns, diverged, disable }) {
   const home = fs.mkdtempSync(path.join(TMP, 'home-'));
   const cacheDir = path.join(home, '.claude', 'cache');
   fs.mkdirSync(cacheDir, { recursive: true });
@@ -78,6 +78,8 @@ function render({ dir, model, remaining, current, currentResetsInMin, weekly, we
   // regardless of the terminal running preview (and the primary line never wraps).
   if (columns != null) env.COLUMNS = String(columns);
   else delete env.COLUMNS;
+  if (disable != null) env.CTXLINE_DISABLE = disable;       // segment opt-out scenario
+  else delete env.CTXLINE_DISABLE;
 
   const res = spawnSync(process.execPath, [SCRIPT], {
     input: JSON.stringify({
@@ -144,3 +146,7 @@ console.log('  ' + render({
     seven_day: { used_percentage: base.weekly, resets_at: nowSec + base.weeklyResetsInMin * 60 }
   }
 }));
+
+// Segment opt-out: CTXLINE_DISABLE hides segments (dir/model/context always render).
+console.log('\nSegment opt-out (CTXLINE_DISABLE=usage,cost):');
+console.log('  ' + render({ ...base, effort: 'high', disable: 'usage,cost' }));

--- a/statusline.js
+++ b/statusline.js
@@ -12,6 +12,17 @@ const { execSync, execFileSync } = require('child_process');
 
 const IS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
 
+// Optional segment opt-out: CTXLINE_DISABLE is a comma list of segments to hide.
+// Recognized: branch, effort, cost, task, usage (H+W). dir/model/context always render.
+// Unknown names are ignored. Disabling a segment also skips its work (git, todo read,
+// usage fetch).
+const DISABLED = new Set(
+  (process.env.CTXLINE_DISABLE || '')
+    .split(',')
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean)
+);
+
 // Shared width (cells) for all progress bars: context, current, weekly.
 const BAR_WIDTH = 6;
 
@@ -503,15 +514,15 @@ function outputStatus(data, usage) {
     const model = shortenModel(data?.model?.display_name || 'Claude');
     const dir = data?.workspace?.current_dir || process.cwd();
     const dirname = path.basename(dir);
-    const branch = getGitBranch(dir);
+    const branch = DISABLED.has('branch') ? '' : getGitBranch(dir);
     const sync = branch ? formatAheadBehind(getGitAheadBehind(dir)) : '';
-    const effort = data?.effort?.level || '';
+    const effort = DISABLED.has('effort') ? '' : (data?.effort?.level || '');
     const sessionId = data?.session_id || '';
     const remaining = data?.context_window?.remaining_percentage;
 
     const contextBar = getContextBar(remaining);
-    const cost = getCostSegment(data);
-    const task = getCurrentTask(sessionId);
+    const cost = DISABLED.has('cost') ? '' : getCostSegment(data);
+    const task = DISABLED.has('task') ? '' : getCurrentTask(sessionId);
 
     // line1 = identity + context (always); line2 = usage/cost/task (wrap target).
     const line1 = [];
@@ -545,7 +556,7 @@ function outputFallback(usage) {
 // Order: API-key users get none; otherwise prefer stdin `rate_limits` (no network),
 // then fall back to the cache+API flow when stdin lacks it (cold start / non-Pro/Max).
 function resolveUsage(data, callback) {
-  if (IS_API_KEY) {
+  if (IS_API_KEY || DISABLED.has('usage')) {
     return callback(null);
   }
   const fromStdin = buildUsageFromStdin(data);

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -34,6 +34,12 @@ function run(input, opts = {}) {
   } else {
     delete env.COLUMNS;
   }
+  // Segment opt-out. Default: unset so a value in the dev env can't skew assertions.
+  if (opts.disable != null) {
+    env.CTXLINE_DISABLE = opts.disable;
+  } else {
+    delete env.CTXLINE_DISABLE;
+  }
   const res = spawnSync(process.execPath, [SCRIPT], { input, encoding: 'utf8', timeout: 5000, env });
   const raw = res.stdout || '';
   const clean = raw.replace(/\x1b\[[0-9;]*m/g, ''); // strip ANSI for readable assertions
@@ -489,4 +495,61 @@ test('counts are cached: a commit within the TTL does not change the rendered co
   const second = run(fixture(40, dir), { home });          // within 5s TTL -> cache hit
   assert.match(second.clean, /↑1/, 'cached ↑1 reused; git not re-run');
   assert.ok(!second.clean.includes('↑2'), 'fresh count must not appear within the TTL');
+});
+
+// Segment opt-out via CTXLINE_DISABLE (comma list; dir/model/context always render).
+
+// HOME seeded with an in-progress todo so the task segment renders for the session id.
+function seedTodo(activeForm) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-todo-'));
+  after(() => fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
+  const todosDir = path.join(home, '.claude', 'todos');
+  fs.mkdirSync(todosDir, { recursive: true });
+  fs.writeFileSync(path.join(todosDir, 'test-session-agent-1.json'),
+    JSON.stringify([{ status: 'in_progress', activeForm }]));
+  return home;
+}
+
+test('disable=cost hides cost; model + context intact', () => {
+  const { clean } = run(fixture(40, '/no/such/repo', 'Opus 4.8', undefined, 0.42), { disable: 'cost' });
+  assert.ok(!clean.includes('$'), 'cost hidden');
+  assert.match(clean, /Opus 4\.8/, 'model still renders');
+  assert.match(clean, /C\d+ /, 'context still renders');
+});
+
+test('disable=effort drops the · level suffix', () => {
+  const { clean } = run(fixture(40, '/no/such/repo', 'Opus 4.8', 'high'), { disable: 'effort' });
+  assert.strictEqual(clean.split(' │ ')[1], 'Opus 4.8', 'no "· high"');
+});
+
+test('disable=branch hides the branch (and ahead/behind) glyph', () => {
+  const repo = seedRepo('feature/x');
+  const { clean } = run(fixture(40, repo), { disable: 'branch' });
+  assert.ok(!clean.includes('⎇'), 'branch segment hidden');
+});
+
+test('disable=usage hides H/W', () => {
+  const home = seedHome({ cacheAgeMs: 5000, percentage: 42, weeklyPercentage: 31 });
+  const { clean } = run(fixture(40), { home, usage: true, disable: 'usage' });
+  assert.ok(!clean.includes('H42') && !clean.includes('W31'), 'usage segments hidden');
+  assert.ok(!clean.includes('↺'), 'no reset countdown');
+  assert.match(clean, /C\d+ /, 'context still renders');
+});
+
+test('disable=task hides the in-progress todo', () => {
+  const home = seedTodo('Refactoring usage cache');
+  assert.match(run(fixture(40), { home }).clean, /Refactoring usage cache/, 'task shows by default (control)');
+  const { clean } = run(fixture(40), { home, disable: 'task' });
+  assert.ok(!clean.includes('Refactoring usage cache'), 'task hidden when disabled');
+});
+
+test('disable with an unknown token changes nothing', () => {
+  const { clean } = run(fixture(40, '/no/such/repo', 'Opus 4.8', undefined, 0.42), { disable: 'bogus,nope' });
+  assert.match(clean, /\$0\.42/, 'cost still renders for unknown tokens');
+});
+
+test('disable accepts multiple segments', () => {
+  const { clean } = run(fixture(40, '/no/such/repo', 'Opus 4.8', 'high', 0.42), { disable: 'cost,effort' });
+  assert.ok(!clean.includes('$'), 'cost hidden');
+  assert.strictEqual(clean.split(' │ ')[1], 'Opus 4.8', 'effort hidden');
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to disable specific statusline segments using the `CTXLINE_DISABLE` environment variable.
  * Supports comma-separated segment names for granular control.

* **Documentation**
  * Expanded README with configuration guidance explaining two setup methods and segment opt-out instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->