### PR TITLE
fix: strip control chars from branch name read from .git/HEAD

### DIFF
--- a/statusline.js
+++ b/statusline.js
@@ -125,7 +125,9 @@ function getGitBranch(dir) {
     if (!gitDir) return '';
     const head = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
     const ref = head.match(/^ref:\s*refs\/heads\/(.+)$/);
-    if (ref) return truncateBranch(ref[1]);
+    // Strip control chars: HEAD is read raw (not git-validated), so a hand-crafted file
+    // in an untrusted archive could inject terminal escape sequences.
+    if (ref) return truncateBranch(ref[1].replace(/[\x00-\x1f\x7f]/g, ''));
     if (/^[0-9a-f]{7,40}$/i.test(head)) return head.slice(0, 7);  // detached HEAD -> short sha
     return '';
   } catch (e) {

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -228,6 +228,13 @@ test('worktree (.git is a file with gitdir:) -> branch still renders', () => {
   assert.match(clean.split(' │ ')[0], /⎇ feature\/wt$/);
 });
 
+test('control chars in a hand-crafted HEAD are stripped from the branch', () => {
+  const repo = seedRepo('bad\x1b[31mname\x07');   // injected ANSI escape + BEL
+  const { raw, clean } = run(fixture(40, repo));
+  assert.ok(!raw.includes('\x1b[31mname'), 'injected escape sequence must not reach output');
+  assert.match(clean.split(' │ ')[0], /⎇ bad\[31mname$/);  // printable remainder kept, controls gone
+});
+
 test('thinking effort renders next to the model (· <level>)', () => {
   const { clean } = run(fixture(40, '/no/such/repo', 'Opus 4.8', 'high'));
   const parts = clean.split(' │ ');


### PR DESCRIPTION
- statusline.js:127-130 — getGitBranch now strips [\x00-\x1f\x7f] from the branch parsed out of .git/HEAD, so a hand-crafted HEAD can't inject ANSI escapes into the terminal. Detached-HEAD path was already regex-validated hex; no change needed there.
- test/render.test.js — new test seeds a HEAD containing \x1b[31m + BEL and asserts the escape bytes never reach output while the printable remainder renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized Git branch names before displaying them in the status line.
  * Prevented control characters, including terminal escape sequences, from appearing in rendered output.

* **Tests**
  * Added coverage to verify that unsafe control characters are removed while printable branch-name text is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->