### PR TITLE
Render model-scoped weekly limits (e.g. Fable at 86%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 | **Context** | Visual bar of context-window usage |
 | **Current** | Live 5-hour session limit + reset countdown (subscription users) |
 | **Weekly** | Weekly usage allowance + time until the weekly reset (subscription users) |
+| **Model limit** | Weekly limit scoped to a single model, when your account has one — labelled by the model's initial (`F` = Fable) |
 | **Cost** | Running session cost in USD (e.g. `$0.42`) |
 | **Task** | The in-progress todo, when there is one |
 
@@ -137,7 +138,7 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 
 The statusline is zero-config by default. To **hide segments you don't want**, set the `CTXLINE_DISABLE` environment variable to a comma-separated list of any of:
 
-`branch` · `effort` · `cost` · `task` · `usage` (5-hour + weekly)
+`branch` · `effort` · `cost` · `task` · `usage` (5-hour + weekly + model-scoped)
 
 Directory, model, and context always show; unknown names are ignored. Example below hides cost and the current task.
 
@@ -181,7 +182,8 @@ To re-enable a segment, remove it from the list (or delete the variable) and res
 
 ## How it works
 
-- **Source** — context comes from Claude Code's session data. Usage bars are read straight from the `rate_limits` field Claude Code pipes in (no network), falling back to `https://api.anthropic.com/api/oauth/usage` (the same `/usage` data — 5-hour and weekly limits) when that field isn't present yet. API-key users skip usage entirely.
+- **Source** — context comes from Claude Code's session data. The 5-hour and weekly bars are read straight from the `rate_limits` field Claude Code pipes in (no network), falling back to `https://api.anthropic.com/api/oauth/usage` when that field isn't present yet. API-key users skip usage entirely.
+- **Model-scoped limits** — `rate_limits` carries only `five_hour` and `seven_day`, so a model-scoped weekly limit can only come from `/usage` (its `limits` array). It's served from the same cache as everything else, so this costs at most one call per 30s no matter how often the line renders.
 - **No network on the fast path** — when `rate_limits` is in the session data, there's no API call at all. The fetch below only runs as a fallback (e.g. the first render of a session, before the field appears).
 - **Adaptive timing** — for the fallback fetch: 1.5s timeout on the first prompt (cold start), 1.2s after (connection reused).
 - **Caching** — the fallback fetch is cached at `~/.claude/cache/usage-cache.json`, shared across sessions. Within 30s the cache renders directly (the API call is skipped); if a live call fails, the last value (up to 10 min old) is shown so the bar never vanishes. The reset countdown recomputes every render.

--- a/statusline.js
+++ b/statusline.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Claude Code Enhanced Statusline
-// Shows: directory | model | context usage | current (5-hour) + weekly usage | current task
+// Shows: directory | model | context usage | 5-hour + weekly + model-scoped usage | current task
 // Auto-detects API key vs subscription usage
 // https://github.com/MithunWijayasiri/ctxline-claude
 
@@ -13,7 +13,7 @@ const { execSync, execFileSync } = require('child_process');
 const IS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
 
 // Optional segment opt-out: CTXLINE_DISABLE is a comma list of segments to hide.
-// Recognized: branch, effort, cost, task, usage (H+W). dir/model/context always render.
+// Recognized: branch, effort, cost, task, usage (H+W+model-scoped). dir/model/context always render.
 // Unknown names are ignored. Disabling a segment also skips its work (git, todo read,
 // usage fetch).
 const DISABLED = new Set(
@@ -240,12 +240,34 @@ function buildUsageBar(label, percentage, resetsAt) {
   return `${color}${label}${percentage}${colors.reset}${timePart}`;
 }
 
-// Build both usage segments from raw entries. Each entry is { percentage, resetsAt } or
-// null/absent. Returns { current, weekly } where each is a rendered segment string or null.
-function buildUsageBars(fiveHour, weekly) {
+// Model-scoped weekly limits (e.g. "Fable weekly limit at 86%"), rendered after the
+// account-wide W bar. The /usage payload reports these in a `limits` array, each entry
+// carrying the model in scope.model.display_name:
+//
+//   { kind: "weekly_scoped", percent: 86, severity: "warning",
+//     resets_at: "...", scope: { model: { display_name: "Fable" } } }
+//
+// The label is the model's first initial (Fable -> F), so a new model family needs no
+// code change. Older payloads instead exposed flat seven_day_<model> keys, kept below as
+// a fallback for accounts still reporting that shape.
+//
+// NOTE: these appear only in the API payload. Claude Code's statusline stdin carries just
+// five_hour and seven_day under rate_limits, so the scoped limits always come from the
+// cache/API path even when stdin supplies the H and W bars.
+const LEGACY_MODEL_WEEKLY_KEYS = [
+  { key: 'seven_day_opus', label: 'O' },
+  { key: 'seven_day_sonnet', label: 'S' }
+];
+
+// Build the usage segments from raw entries. fiveHour/weekly are { percentage, resetsAt }
+// or null/absent; models is an array of { label, percentage, resetsAt } (possibly empty).
+// Returns { current, weekly, models } — the first two rendered strings or null, models a
+// (possibly empty) array of rendered strings.
+function buildUsageBars(fiveHour, weekly, models) {
   return {
     current: fiveHour ? buildUsageBar('H', fiveHour.percentage, fiveHour.resetsAt) : null,
-    weekly: weekly ? buildUsageBar('W', weekly.percentage, weekly.resetsAt) : null
+    weekly: weekly ? buildUsageBar('W', weekly.percentage, weekly.resetsAt) : null,
+    models: (models || []).map(m => buildUsageBar(m.label, m.percentage, m.resetsAt))
   };
 }
 
@@ -257,11 +279,42 @@ function normalizePercentage(value) {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
+// Extract the model-scoped weekly limits from a raw /usage payload as
+// [{ label, percentage, resetsAt }], in payload order. Prefers the `limits` array;
+// falls back to the legacy flat keys only when it yields nothing, so an account
+// reporting both shapes doesn't render the same limit twice.
+function parseScopedLimits(usage) {
+  const scoped = [];
+
+  if (Array.isArray(usage?.limits)) {
+    for (const entry of usage.limits) {
+      if (!entry || entry.kind !== 'weekly_scoped') continue;
+      const name = entry.scope?.model?.display_name;
+      const pct = normalizePercentage(entry.percent);
+      if (typeof name !== 'string' || !name.trim() || pct == null) continue;
+      scoped.push({
+        label: name.trim().charAt(0).toUpperCase(),
+        percentage: pct,
+        resetsAt: entry.resets_at || null
+      });
+    }
+    if (scoped.length) return scoped;
+  }
+
+  for (const { key, label } of LEGACY_MODEL_WEEKLY_KEYS) {
+    const seg = usage?.[key];
+    const pct = seg ? normalizePercentage(seg.utilization) : null;
+    if (pct != null) scoped.push({ label, percentage: pct, resetsAt: seg.resets_at || null });
+  }
+  return scoped;
+}
+
 // Build usage bars from stdin `rate_limits` (Claude.ai Pro/Max, present only after the
 // first API response of a session). Same data as the OAuth usage API, so reading it here
 // skips the network/credentials/cache path entirely. `resets_at` is a Unix epoch in
-// SECONDS (not ISO) — ×1000 before Date. Returns { current, weekly } bars, or null when
-// rate_limits is absent or the required five_hour segment is unusable (caller falls back).
+// SECONDS (not ISO) — ×1000 before Date. Returns raw { fiveHour, weekly } entries, or null
+// when rate_limits is absent or the required five_hour segment is unusable (caller falls
+// back). Model-scoped weekly limits are never present here — see LEGACY_MODEL_WEEKLY_KEYS.
 function buildUsageFromStdin(data) {
   const rl = data?.rate_limits;
   if (!rl) return null;
@@ -284,8 +337,7 @@ function buildUsageFromStdin(data) {
 
   const fiveHour = toEntry(rl.five_hour);
   if (!fiveHour) return null;          // five_hour is the required bar
-  const weekly = toEntry(rl.seven_day);
-  return buildUsageBars(fiveHour, weekly);
+  return { fiveHour, weekly: toEntry(rl.seven_day) };
 }
 
 // Validate a single usage entry ({ percentage, resetsAt }). Returns true only for a
@@ -307,13 +359,18 @@ function readCachedUsage() {
     const cache = JSON.parse(fs.readFileSync(USAGE_CACHE_FILE, 'utf8'));
     if (!cache || !Number.isFinite(cache.timestamp) || cache.timestamp <= 0) return null;
 
-    // Validate data. fiveHour is required; weekly is optional (the API may omit it).
-    // This also rejects the legacy single-{percentage,resetsAt} format from older
-    // versions, which had no fiveHour key, so stale caches are ignored on read.
+    // Validate data. fiveHour is required; weekly and models are optional (the API may
+    // omit either). This also rejects the legacy single-{percentage,resetsAt} format from
+    // older versions, which had no fiveHour key, so stale caches are ignored on read.
+    // A cache written before model bars existed simply has no models key — still valid.
     const data = cache.data;
     if (!data || typeof data !== 'object') return null;
     if (!isValidUsageEntry(data.fiveHour)) return null;
     if (data.weekly != null && !isValidUsageEntry(data.weekly)) return null;
+    if (data.models != null) {
+      if (!Array.isArray(data.models)) return null;
+      if (!data.models.every(m => typeof m?.label === 'string' && isValidUsageEntry(m))) return null;
+    }
 
     return { age: Date.now() - cache.timestamp, data };
   } catch (e) {
@@ -412,9 +469,13 @@ function getApiUsage(callback) {
               resetsAt: usage.seven_day.resets_at || null
             } : null;
 
-            // Cache the raw data (shared across sessions); render the bars from it.
-            setCachedUsage({ fiveHour, weekly });
-            callback(buildUsageBars(fiveHour, weekly));
+            // Model-scoped weekly limits, rendered only when the account reports them.
+            const models = parseScopedLimits(usage);
+
+            // Cache the raw data (shared across sessions); callers render from it.
+            const resolved = { fiveHour, weekly, models };
+            setCachedUsage(resolved);
+            callback(resolved);
           } else {
             callback(null);
           }
@@ -436,26 +497,40 @@ function getApiUsage(callback) {
   }
 }
 
-// Get usage, cache-first.
-function getUsageWithCache(callback) {
+// Resolve raw usage data ({ fiveHour, weekly, models }), cache-first. Callers render it.
+function getRawUsage(callback) {
   const cached = readCachedUsage();
 
-  // Cache is fresh -> render it and skip the API entirely (fewer calls, faster).
+  // Cache is fresh -> use it and skip the API entirely (fewer calls, faster).
   if (cached && cached.age < FRESH_TTL_MS) {
-    return callback(buildUsageBars(cached.data.fiveHour, cached.data.weekly));
+    return callback(cached.data);
   }
 
   // Cache is stale or missing -> refresh from the API.
-  getApiUsage((freshBars) => {
-    if (freshBars) {
-      callback(freshBars);
+  getApiUsage((fresh) => {
+    if (fresh) {
+      callback(fresh);
     } else if (cached && cached.age < STALE_TTL_MS) {
       // API failed/timed out, but recent cache exists -> show it instead of nothing.
-      callback(buildUsageBars(cached.data.fiveHour, cached.data.weekly));
+      callback(cached.data);
     } else {
       callback(null);
     }
   });
+}
+
+// Get usage, cache-first, rendered.
+function getUsageWithCache(callback) {
+  getRawUsage((data) => {
+    callback(data ? buildUsageBars(data.fiveHour, data.weekly, data.models) : null);
+  });
+}
+
+// Model-scoped weekly limits only, cache-first. Used alongside the stdin H/W bars, which
+// can't carry them. Falls back to the stale cache and finally to [] so a failed or slow
+// call costs the scoped bars but never the bars stdin already gave us.
+function getScopedModels(callback) {
+  getRawUsage((data) => callback(data?.models || []));
 }
 
 // Session cost from stdin `cost.total_cost_usd` (USD float, computed client-side by
@@ -537,6 +612,7 @@ function outputStatus(data, usage) {
     const line2 = [];
     if (usage?.current) line2.push(usage.current);
     if (usage?.weekly) line2.push(usage.weekly);
+    if (usage?.models?.length) line2.push(...usage.models);
     if (cost) line2.push(cost);
     if (task) line2.push(`${colors.dim}${task}${colors.reset}`);
 
@@ -551,6 +627,7 @@ function outputFallback(usage) {
   const parts = ['~', 'Claude', contextBar];
   if (usage?.current) parts.push(usage.current);
   if (usage?.weekly) parts.push(usage.weekly);
+  if (usage?.models?.length) parts.push(...usage.models);
   process.stdout.write(parts.join(' \u2502 '));
 }
 
@@ -563,7 +640,12 @@ function resolveUsage(data, callback) {
   }
   const fromStdin = buildUsageFromStdin(data);
   if (fromStdin) {
-    return callback(fromStdin);
+    // stdin covers H and W with no network. Model-scoped weekly limits only exist in the
+    // API payload, so they come from the cache — refreshed on the same TTL as every other
+    // usage read, which keeps at most one call per FRESH_TTL_MS regardless of render rate.
+    return getScopedModels((models) => {
+      callback(buildUsageBars(fromStdin.fiveHour, fromStdin.weekly, models));
+    });
   }
   getUsageWithCache(callback);
 }
@@ -591,24 +673,31 @@ function emit(data) {
   });
 }
 
-if (process.stdin.isTTY) {
-  emit(null);
+// Entry point, guarded so tests can require this file to exercise payload parsing
+// directly (the /usage response shape is the easiest thing here to get wrong, and it
+// can't be reached through stdin). Running the script normally is unchanged.
+if (require.main === module) {
+  if (process.stdin.isTTY) {
+    emit(null);
+  } else {
+    let input = '';
+    let timeoutReached = false;
+
+    const overallTimeout = IS_API_KEY ? 500 : (fs.existsSync(USAGE_CACHE_FILE) ? 1300 : 1600);
+
+    const timeout = setTimeout(() => {
+      timeoutReached = true;
+      emit(parseInput(input));
+    }, overallTimeout);
+
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => input += chunk);
+    process.stdin.on('end', () => {
+      if (timeoutReached) return;
+      clearTimeout(timeout);
+      emit(parseInput(input));
+    });
+  }
 } else {
-  let input = '';
-  let timeoutReached = false;
-
-  const overallTimeout = IS_API_KEY ? 500 : (fs.existsSync(USAGE_CACHE_FILE) ? 1300 : 1600);
-
-  const timeout = setTimeout(() => {
-    timeoutReached = true;
-    emit(parseInput(input));
-  }, overallTimeout);
-
-  process.stdin.setEncoding('utf8');
-  process.stdin.on('data', chunk => input += chunk);
-  process.stdin.on('end', () => {
-    if (timeoutReached) return;
-    clearTimeout(timeout);
-    emit(parseInput(input));
-  });
+  module.exports = { parseScopedLimits, normalizePercentage };
 }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -82,6 +82,7 @@ function fixture(remaining, dir = '/tmp/myproject', model = 'Opus 4.8', effort, 
 
 // stdin payload carrying `rate_limits` (Claude.ai Pro/Max, post-first-response).
 // resets_at is a Unix epoch in SECONDS. 5h ~2h out, 7d ~62h out (exercises day-aware countdown).
+// Claude Code pipes only five_hour and seven_day here — never a model-scoped limit.
 function fixtureWithRateLimits(remaining, { five = 23.5, seven = 41.2 } = {}) {
   const nowSec = Math.floor(Date.now() / 1000);
   return JSON.stringify({
@@ -94,6 +95,18 @@ function fixtureWithRateLimits(remaining, { five = 23.5, seven = 41.2 } = {}) {
       seven_day: { used_percentage: seven, resets_at: nowSec + 62 * 3600 }
     }
   });
+}
+
+// Add model-scoped limits to an already-seeded cache, so the render path can be tested
+// without a network call. Each entry is { label, percentage }; the reset is 62h out.
+function seedScopedCache(home, models) {
+  const cacheFile = path.join(home, '.claude', 'cache', 'usage-cache.json');
+  const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+  cache.data.models = models.map(m => ({
+    ...m,
+    resetsAt: new Date(Date.now() + 62 * 3600 * 1000).toISOString()
+  }));
+  fs.writeFileSync(cacheFile, JSON.stringify(cache));
 }
 
 // Make a real dir with a seeded .git/HEAD so the branch segment renders deterministically.
@@ -377,6 +390,131 @@ test('stdin rate_limits -> 5h/7d render with no cache and no creds', () => {
   assert.match(clean, /H24\b/);                                 // 23.5 -> 24 (fractional, rounded)
   assert.match(clean, /W41\b/);                                 // 41.2 -> 41
   assert.match(clean, /W41 ↺ 2d\d{1,2}h/);                      // epoch-seconds -> day-aware countdown
+});
+
+// Model-scoped weekly limits ("Fable weekly limit at 86%"). The /usage payload reports
+// these in a `limits` array; they never appear on stdin, so they always come from the
+// cache/API path. parseScopedLimits is exercised directly against the real payload shape.
+
+const { parseScopedLimits } = require('../statusline.js');
+
+// A trimmed copy of a real GET /api/oauth/usage response: the legacy seven_day_<model>
+// keys are all null, and the live scoped limit lives in `limits`.
+function usagePayload({ scopedPercent = 86, model = 'Fable' } = {}) {
+  return {
+    five_hour: { utilization: 43, resets_at: '2026-08-02T17:00:00+00:00' },
+    seven_day: { utilization: 63, resets_at: '2026-08-05T13:00:00+00:00' },
+    seven_day_opus: null,
+    seven_day_sonnet: null,
+    limits: [
+      { kind: 'session', group: 'session', percent: 43, resets_at: '2026-08-02T17:00:00+00:00', scope: null },
+      { kind: 'weekly_all', group: 'weekly', percent: 63, resets_at: '2026-08-05T13:00:00+00:00', scope: null },
+      {
+        kind: 'weekly_scoped', group: 'weekly', percent: scopedPercent, severity: 'warning',
+        resets_at: '2026-08-05T13:00:00+00:00', is_active: true,
+        scope: { model: { id: null, display_name: model } }
+      }
+    ]
+  };
+}
+
+test('parseScopedLimits picks weekly_scoped out of the limits array', () => {
+  const scoped = parseScopedLimits(usagePayload());
+  assert.deepStrictEqual(scoped, [
+    { label: 'F', percentage: 86, resetsAt: '2026-08-05T13:00:00+00:00' }
+  ]);
+});
+
+test('parseScopedLimits ignores session and weekly_all entries', () => {
+  // percent 43 (session) and 63 (weekly_all) must not leak in as scoped bars.
+  const scoped = parseScopedLimits(usagePayload());
+  assert.strictEqual(scoped.length, 1, 'only the weekly_scoped entry is a model bar');
+  assert.ok(!scoped.some(s => s.percentage === 43 || s.percentage === 63));
+});
+
+test('parseScopedLimits labels by model initial, so a new family needs no code change', () => {
+  assert.strictEqual(parseScopedLimits(usagePayload({ model: 'Opus' }))[0].label, 'O');
+  assert.strictEqual(parseScopedLimits(usagePayload({ model: 'sonnet' }))[0].label, 'S');
+  assert.strictEqual(parseScopedLimits(usagePayload({ model: 'Newmodel' }))[0].label, 'N');
+});
+
+test('parseScopedLimits skips malformed entries instead of rendering NaN', () => {
+  const payload = usagePayload();
+  payload.limits.push({ kind: 'weekly_scoped', percent: null, scope: { model: { display_name: 'Ghost' } } });
+  payload.limits.push({ kind: 'weekly_scoped', percent: 50, scope: { model: {} } });
+  payload.limits.push({ kind: 'weekly_scoped', percent: 50, scope: null });
+  const scoped = parseScopedLimits(payload);
+  assert.strictEqual(scoped.length, 1, 'only the well-formed entry survives');
+  assert.ok(!scoped.some(s => s.label === 'G'));
+});
+
+test('parseScopedLimits falls back to legacy seven_day_<model> keys when limits is absent', () => {
+  const legacy = {
+    five_hour: { utilization: 43 },
+    seven_day_opus: { utilization: 77, resets_at: '2026-08-05T13:00:00+00:00' },
+    seven_day_sonnet: null
+  };
+  assert.deepStrictEqual(parseScopedLimits(legacy), [
+    { label: 'O', percentage: 77, resetsAt: '2026-08-05T13:00:00+00:00' }
+  ]);
+});
+
+test('parseScopedLimits does not double-count when both shapes are present', () => {
+  const both = usagePayload();
+  both.seven_day_opus = { utilization: 77, resets_at: '2026-08-05T13:00:00+00:00' };
+  const scoped = parseScopedLimits(both);
+  assert.strictEqual(scoped.length, 1, 'the limits array wins outright');
+  assert.strictEqual(scoped[0].label, 'F');
+});
+
+test('no scoped limits -> nothing extra renders', () => {
+  assert.deepStrictEqual(parseScopedLimits({ five_hour: { utilization: 43 } }), []);
+  const { clean } = run(fixtureWithRateLimits(40), { usage: true });
+  assert.match(clean, /H24\b/);
+  assert.match(clean, /W41\b/);
+  assert.ok(!/\bF\d+/.test(clean), 'no F bar when the account reports no scoped limit');
+});
+
+// Rendering: scoped bars come from the cache, including on the stdin fast path.
+
+test('scoped bar renders alongside the stdin H/W bars', () => {
+  // The crux of the feature: stdin supplies H/W (no network), the scoped limit comes from
+  // the cache. Before this, a scoped limit could never reach the screen in a live session.
+  const home = seedHome({ cacheAgeMs: 5000 });
+  seedScopedCache(home, [{ label: 'F', percentage: 86 }]);
+  const { code, clean } = run(fixtureWithRateLimits(40), { home, usage: true });
+  assert.strictEqual(code, 0);
+  assert.match(clean, /H24\b/, 'H still comes from stdin, not the cache');
+  assert.match(clean, /W41\b/, 'W still comes from stdin');
+  assert.match(clean, /F86\b/, 'scoped bar comes from the cache');
+});
+
+test('scoped bars render after W, in payload order', () => {
+  const home = seedHome({ cacheAgeMs: 5000 });
+  seedScopedCache(home, [{ label: 'O', percentage: 12 }, { label: 'F', percentage: 86 }]);
+  const { clean } = run(fixtureWithRateLimits(40), { home, usage: true });
+  const parts = clean.split('│').map(s => s.trim());
+  const idx = (re) => parts.findIndex(p => re.test(p));
+  assert.ok(idx(/^W\d+/) < idx(/^O\d+/), 'W precedes the scoped bars');
+  assert.ok(idx(/^O\d+/) < idx(/^F\d+/), 'scoped bars keep payload order');
+});
+
+test('CTXLINE_DISABLE=usage also hides the scoped bars', () => {
+  const home = seedHome({ cacheAgeMs: 5000 });
+  seedScopedCache(home, [{ label: 'F', percentage: 86 }]);
+  const { clean } = run(fixtureWithRateLimits(40), { home, usage: true, disable: 'usage' });
+  assert.ok(!/\bF\d+/.test(clean), 'scoped bar is part of the usage segment');
+  assert.ok(!clean.includes('H24'), 'H bar hidden too');
+});
+
+test('a cache written before scoped bars existed stays valid', () => {
+  // No `models` key at all — must be accepted (H/W render, no scoped bars) rather than
+  // rejected as malformed, which would force a refetch for everyone on upgrade.
+  const home = seedHome({ cacheAgeMs: 5000, percentage: 42, weeklyPercentage: 31 });
+  const { clean } = run(fixture(40), { home, usage: true });
+  assert.match(clean, /H42\b/, 'legacy cache without models is still readable');
+  assert.match(clean, /W31\b/);
+  assert.ok(!/\bF\d+/.test(clean));
 });
 
 test('stdin rate_limits takes precedence over a fresh cache', () => {


### PR DESCRIPTION
## Problem

An account can have a weekly limit scoped to a **single model**. `GET /api/oauth/usage` reports it in a `limits` array:

```json
{ "kind": "weekly_scoped", "group": "weekly", "percent": 86, "severity": "warning",
  "resets_at": "2026-08-05T13:00:00+00:00", "is_active": true,
  "scope": { "model": { "id": null, "display_name": "Fable" } } }
```

Nothing renders it today. That's a real blind spot: on my account the statusline reads a comfortable `W63` while the Fable weekly limit sits at **86%**. `W` tracks `seven_day` (all models) and never moves with the scoped one, so the first sign of trouble is hitting the limit.

## Change

Each scoped limit renders as its own bar after `W`, via the existing `buildUsageBar` — same colors, same `↺` countdown:

```
ClaudeStatusBar ⎇ main │ Opus 5 (1M) · high │ C38 ██░░░░ │ H43 ↺ 1h59m │ W63 ↺ 2d13h │ F86 ↺ 2d23h
```

The label is the model's initial (`Fable` → `F`), so a new model family needs no code change. Accounts without a scoped limit render exactly as before.

## Two things worth your review

**1. Source of truth is `limits`, not the flat keys.** `seven_day_opus` / `seven_day_sonnet` still exist in the payload but read `null` on a current account — the live data is in `limits`. I kept the flat keys as a fallback, used only when `limits` yields nothing, so the two shapes can't double-count.

**2. The stdin fast path is no longer strictly network-free.** Claude Code's documented statusline schema carries only `five_hour` and `seven_day` under `rate_limits` — a scoped limit can never arrive that way. So it comes from the cache/API path even when stdin supplies H and W.

I know that cuts against the "no network on the fast path" property, so I kept the cost bounded: it reuses the existing `FRESH_TTL_MS` cache, so it's at most one call per 30s regardless of render rate, and a failed or slow call costs only the scoped bar — the stdin-supplied H/W bars still render. If you'd rather keep the fast path absolutely network-free, the alternative is gating this behind an opt-in env var; happy to switch it.

## Testability

The entry point is now guarded by `require.main === module`, exporting `parseScopedLimits` when required. The `/usage` response shape is the easiest thing here to get wrong and it can't be reached through stdin — I got it wrong myself on the first pass, which is why it's now unit-tested against a real payload. Running the script is unchanged.

## Tests

11 new cases, 61 pass / 0 fail. Parsing: scoped entries picked out while `session` and `weekly_all` are ignored, label derivation, malformed entries skipped rather than rendering `NaN`, legacy-key fallback, no double-count when both shapes are present. Rendering: scoped bar alongside stdin-supplied bars, ordering after `W`, `CTXLINE_DISABLE=usage` covering it, and a pre-`models` cache staying valid so nobody eats a forced refetch on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying weekly usage limits per model, labeled by model initial.
  * Model-specific limits are shown alongside account-wide weekly usage.
  * Added handling for usage data from the API and cached data, including fallback behavior when cache data is outdated or unavailable.

* **Documentation**
  * Updated usage documentation to explain model-scoped weekly limits and configurable usage display segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->