### PR TITLE
feat: render subagent rows via subagentStatusLine mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ npm pack --dry-run # preview what publishes
 
 # Ad-hoc render — feed the stdin JSON Claude Code sends:
 echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp/x"},"session_id":"t","context_window":{"remaining_percentage":40}}' | node statusline.js
+
+# Ad-hoc subagent-row render (subagentStatusLine mode — see below):
+echo '{"tasks":[{"id":"t1","name":"reviewer","model":"claude-opus-5","effort":"max","tokenCount":45200,"contextWindowSize":200000}]}' | node statusline.js subagent
 ```
 
 Publishing + local-install detail: `docs/DEV.md`.
@@ -62,6 +65,20 @@ Entry point guarded by `require.main === module` so `test/render.test.js` can `r
 - `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (a render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
 
 **Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg, so several scoped bars read as one group while a nearly-spent one still stands out.
+
+## Subagent mode (`subagentStatusLine`)
+
+A second entry point in the same file, activated by `process.argv[2] === 'subagent'` — wired in `settings.json` as a separate command from `statusLine`:
+
+```json
+{ "subagentStatusLine": { "type": "command", "command": "node ~/.claude/hooks/statusline.js subagent" } }
+```
+
+Renders one row per running subagent task in the agent panel. Stdin is `{ tasks: [...], ... }` (base fields like `session_id`/`cwd`/`columns` are present but unused); each task carries `id`, `name`/`description`/`label`, `type`, `status`, `startTime`, `model` (resolved ID, absent until resolved), `effort` (level string or numeric token budget, absent when the subagent inherits the session effort), `contextWindowSize`, `tokenCount`, `tokenSamples`, `cwd`. Stdout is one `{"id","content"}` JSON line per task to override — omitting a task's id keeps its default rendering, an empty `content` hides the row.
+
+Row: `name │ Model · effort │ C<used> <bar> │ <tok> tok`, built by `renderSubagentTask()`. Reuses the main line's building blocks rather than duplicating them: `SEGMENT_SEP`, `renderContextBar()` (the used%→bar/color part factored out of `getContextBar`, shared by both), `getEffortColor()`. `shortenModelId()` shortens the resolved model *ID* ("claude-opus-5" → "Opus 5", strips `us.`/`anthropic.` prefixes and a trailing `-YYYYMMDD` date) — distinct from `shortenModel()`, which only trims `" context)"` off a display *name*. Every segment past `name` is independently conditional: no `model` → no model/effort segment (effort alone still renders if present); no `effort` → no `· effort` suffix; `tokenCount`/`contextWindowSize` not both finite (or window ≤ 0) → no context bar; `tokenCount` not finite → no token count.
+
+Skips everything main mode does besides stdin parsing — no usage API, no git, no todos, no cache — so there's no `overallTimeout` race against a fetch; `emitSubagent()` just hard-caps the stdin read at `SUBAGENT_TIMEOUT_MS`. A bad/missing payload, or a task whose shape breaks rendering, emits nothing rather than a partial line — default rendering stays for every task in the panel, and the process still exits 0.
 
 ## Keep in sync when `statusline.js` changes
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ chmod +x ~/.claude/hooks/statusline.js
 }
 ```
 
+**Subagent rows.** The same script also renders per-task rows in the agent panel for running subagents — wire it as a separate `subagentStatusLine` command:
+
+```json
+{
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "node ~/.claude/hooks/statusline.js subagent"
+  }
+}
+```
+
 </details>
 
 ## Update

--- a/statusline.js
+++ b/statusline.js
@@ -54,6 +54,10 @@ const GIT_FRESH_TTL_MS = 5000;          // 5s: reuse counts within a render burs
 const GIT_STALE_TTL_MS = 60000;         // 60s: fall back to last counts if git fails
 const GIT_TIMEOUT_MS = 500;             // hard cap on the rev-list subprocess (warm ~130ms)
 
+// Subagent mode reads only stdin (no usage API to race), so its stdin read gets a
+// short hard cap of its own instead of the main-mode overallTimeout.
+const SUBAGENT_TIMEOUT_MS = 500;
+
 // ANSI color codes
 const colors = {
   reset: '\x1b[0m',
@@ -94,6 +98,19 @@ function getScopedColor(percentage) {
 // Shorten verbose model names for the statusline: "Opus 4.8 (1M context)" -> "Opus 4.8 (1M)".
 function shortenModel(name) {
   return name.replace(/\s+context\)/i, ')');
+}
+
+// Shorten a resolved model ID (subagent task.model, e.g. "claude-opus-5") for the
+// subagent row: "claude-opus-5" -> "Opus 5", "claude-haiku-4-5-20251001" -> "Haiku 4.5".
+// Distinct from shortenModel, which trims a display name rather than parsing an ID.
+function shortenModelId(id) {
+  if (!id) return '';
+  const stripped = String(id).replace(/^(us\.)?(anthropic\.)?claude-/, '').replace(/-\d{8}$/, '');
+  const [family, ...rest] = stripped.split('-');
+  if (!family) return stripped;
+  const name = family[0].toUpperCase() + family.slice(1);
+  const version = rest.join('.');
+  return version ? `${name} ${version}` : name;
 }
 
 // Tail-truncate an over-long branch name, preserving the leading ticket ID.
@@ -208,10 +225,11 @@ function formatAheadBehind(ab) {
   return s;
 }
 
-function getContextBar(remaining) {
-  const effectiveRemaining = remaining ?? 100;
-  const used = Math.max(0, Math.min(100, 100 - Math.round(effectiveRemaining)));
-
+// Colored "C<used> <bar>" (e.g. "C45 ███░░░") for an already-clamped 0-100 used
+// percentage. Shared by the main context bar (derived from remaining%) and the
+// subagent row (derived from tokenCount/contextWindowSize) so both use the same
+// thresholds and bar style.
+function renderContextBar(used) {
   const filled = Math.round((used / 100) * BAR_WIDTH);
   const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(BAR_WIDTH - filled);
 
@@ -222,8 +240,13 @@ function getContextBar(remaining) {
   else if (used < 80) color = colors.orange;
   else color = colors.blink + colors.red;
 
-  // Compact label form: "C<used> <bar>" (e.g. "C45 ███░░░"), colored as a whole.
   return `${color}C${used} ${bar}${colors.reset}`;
+}
+
+function getContextBar(remaining) {
+  const effectiveRemaining = remaining ?? 100;
+  const used = Math.max(0, Math.min(100, 100 - Math.round(effectiveRemaining)));
+  return renderContextBar(used);
 }
 
 // Render a compact usage segment from raw data: "<label><pct> ↺ <countdown>"
@@ -682,11 +705,80 @@ function emit(data) {
   });
 }
 
+// "45200" -> "45.2k tok" ; "800" -> "800 tok". '' when not finite (segment omitted).
+function formatTokenCount(n) {
+  if (!Number.isFinite(n)) return '';
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+// One subagentStatusLine row: "name │ Model · effort │ C<used> <bar> │ <tok> tok".
+// Every segment past name is conditional on its source being present/finite.
+function renderSubagentTask(t) {
+  const parts = [t.label || t.name || t.description || 'agent'];
+
+  const model = shortenModelId(t.model);
+  // effort absent = subagent inherits the session effort; show model alone then.
+  const effort = t.effort != null ? String(t.effort) : '';
+  if (model) {
+    parts.push(effort
+      ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}`
+      : model);
+  } else if (effort) {
+    parts.push(`${getEffortColor(effort)}${effort}${colors.reset}`);
+  }
+
+  if (Number.isFinite(t.tokenCount) && Number.isFinite(t.contextWindowSize) && t.contextWindowSize > 0) {
+    const used = Math.max(0, Math.min(100, Math.round((t.tokenCount / t.contextWindowSize) * 100)));
+    parts.push(renderContextBar(used));
+  }
+
+  const tok = formatTokenCount(t.tokenCount);
+  if (tok) parts.push(`${colors.dim}${tok} tok${colors.reset}`);
+
+  return parts.join(SEGMENT_SEP);
+}
+
+// subagentStatusLine mode: emit one {id, content} JSON line per task with an id, then
+// exit. No usage/git/todos/cache work — the task objects carry everything needed.
+// Bad payload or a task that fails to render -> emit nothing, keeping default
+// rendering for every task, rather than a partial/broken output.
+function emitSubagent(data) {
+  try {
+    const tasks = Array.isArray(data?.tasks) ? data.tasks : [];
+    const out = tasks
+      .filter(t => t && t.id)
+      .map(t => JSON.stringify({ id: t.id, content: renderSubagentTask(t) }))
+      .join('\n');
+    if (out) process.stdout.write(out + '\n');
+  } catch (e) {}
+  process.exit(0);
+}
+
 // Entry point, guarded so tests can require this file to exercise payload parsing
 // directly (the /usage response shape is the easiest thing here to get wrong, and it
 // can't be reached through stdin). Running the script normally is unchanged.
 if (require.main === module) {
-  if (process.stdin.isTTY) {
+  if (process.argv[2] === 'subagent') {
+    if (process.stdin.isTTY) {
+      emitSubagent(null);
+    } else {
+      let input = '';
+      let timeoutReached = false;
+
+      const timeout = setTimeout(() => {
+        timeoutReached = true;
+        emitSubagent(parseInput(input));
+      }, SUBAGENT_TIMEOUT_MS);
+
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', chunk => input += chunk);
+      process.stdin.on('end', () => {
+        if (timeoutReached) return;
+        clearTimeout(timeout);
+        emitSubagent(parseInput(input));
+      });
+    }
+  } else if (process.stdin.isTTY) {
     emit(null);
   } else {
     let input = '';

--- a/statusline.js
+++ b/statusline.js
@@ -749,7 +749,13 @@ function emitSubagent(data) {
       .filter(t => t && t.id)
       .map(t => JSON.stringify({ id: t.id, content: renderSubagentTask(t) }))
       .join('\n');
-    if (out) process.stdout.write(out + '\n');
+    if (out) {
+      // Exit from the write callback: process.exit() would drop output still queued
+      // behind stdout backpressure. A write error (e.g. EPIPE) also lands here — the
+      // callback form reports it instead of throwing, and the answer is the same: exit 0.
+      process.stdout.write(out + '\n', () => process.exit(0));
+      return;
+    }
   } catch (e) {}
   process.exit(0);
 }
@@ -763,20 +769,24 @@ if (require.main === module) {
       emitSubagent(null);
     } else {
       let input = '';
-      let timeoutReached = false;
+      let finished = false;
 
-      const timeout = setTimeout(() => {
-        timeoutReached = true;
+      // Single guarded exit shared by all three triggers: timeout, stdin 'end', and
+      // stdin 'error' (which can fire before 'end' and would otherwise throw unhandled,
+      // breaking the never-throw contract). Whatever accumulated so far gets rendered.
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeout);
         emitSubagent(parseInput(input));
-      }, SUBAGENT_TIMEOUT_MS);
+      };
+
+      const timeout = setTimeout(finish, SUBAGENT_TIMEOUT_MS);
 
       process.stdin.setEncoding('utf8');
       process.stdin.on('data', chunk => input += chunk);
-      process.stdin.on('end', () => {
-        if (timeoutReached) return;
-        clearTimeout(timeout);
-        emitSubagent(parseInput(input));
-      });
+      process.stdin.on('end', finish);
+      process.stdin.on('error', finish);
     }
   } else if (process.stdin.isTTY) {
     emit(null);

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -717,3 +717,90 @@ test('disable accepts multiple segments', () => {
   assert.ok(!clean.includes('$'), 'cost hidden');
   assert.strictEqual(clean.split(' │ ')[1], 'Opus 4.8', 'effort hidden');
 });
+
+// Subagent mode (subagentStatusLine): `node statusline.js subagent` reads stdin
+// `{ tasks: [...] }` and prints one `{id, content}` JSON line per task with an id.
+// content is JSON-encoded, so its \x1b bytes arrive as literal "" text in raw
+// stdout — parse each line first, then strip ANSI from the decoded content.
+
+function runSubagent(input, opts = {}) {
+  const home = opts.home || FAKE_HOME;
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  const res = spawnSync(process.execPath, [SCRIPT, 'subagent'], { input, encoding: 'utf8', timeout: 5000, env });
+  const raw = res.stdout || '';
+  const lines = raw.trim() ? raw.trim().split('\n').map(l => JSON.parse(l)) : [];
+  return { code: res.status, raw, lines };
+}
+
+function cleanContent(s) {
+  return s.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+test('subagent: full task renders name │ model · effort │ context bar │ token count', () => {
+  const input = JSON.stringify({ tasks: [
+    { id: 't1', name: 'reviewer', model: 'claude-opus-5', effort: 'max', tokenCount: 45200, contextWindowSize: 200000 }
+  ] });
+  const { code, lines } = runSubagent(input);
+  assert.strictEqual(code, 0);
+  assert.strictEqual(lines.length, 1);
+  assert.strictEqual(lines[0].id, 't1');
+  const parts = cleanContent(lines[0].content).split(' │ ');
+  assert.strictEqual(parts[0], 'reviewer');
+  assert.strictEqual(parts[1], 'Opus 5 · max');
+  assert.match(parts[2], /^C23 /);                    // 45200/200000 = 22.6% -> rounds to 23
+  assert.strictEqual(parts[3], '45.2k tok');
+  assert.ok(lines[0].content.includes(RED), 'max effort is red, same as the main line');
+});
+
+test('subagent: absent model and effort -> only name and token count render', () => {
+  const input = JSON.stringify({ tasks: [{ id: 't2', name: 'explorer', tokenCount: 800 }] });
+  const { lines } = runSubagent(input);
+  assert.strictEqual(cleanContent(lines[0].content), 'explorer │ 800 tok');
+});
+
+test('subagent: absent effort (inherited) -> model renders alone, no "· effort"', () => {
+  const input = JSON.stringify({ tasks: [{ id: 't3', name: 'x', model: 'claude-sonnet-5' }] });
+  const { lines } = runSubagent(input);
+  assert.strictEqual(cleanContent(lines[0].content), 'x │ Sonnet 5');
+});
+
+test('subagent: numeric effort (token budget) renders as-is, dim', () => {
+  const input = JSON.stringify({ tasks: [
+    { id: 't4', name: 'x', model: 'claude-haiku-4-5-20251001', effort: 12000 }
+  ] });
+  const { lines } = runSubagent(input);
+  assert.strictEqual(cleanContent(lines[0].content), 'x │ Haiku 4.5 · 12000');
+  assert.ok(lines[0].content.includes(`${DIM} · 12000`), 'numeric effort uses the dim style');
+});
+
+test('subagent: bad payload -> no output lines, exit 0', () => {
+  const { code, raw } = runSubagent('not json at all');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(raw, '');
+});
+
+test('subagent: missing tasks array -> no output, exit 0', () => {
+  const { code, raw } = runSubagent('{}');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(raw, '');
+});
+
+test('subagent: task without an id is skipped', () => {
+  const { raw } = runSubagent(JSON.stringify({ tasks: [{ name: 'noid' }] }));
+  assert.strictEqual(raw, '');
+});
+
+test('subagent: model-ID shortening - "claude-opus-5" -> "Opus 5"', () => {
+  const { lines } = runSubagent(JSON.stringify({ tasks: [{ id: 't', model: 'claude-opus-5' }] }));
+  assert.strictEqual(cleanContent(lines[0].content), 'agent │ Opus 5');
+});
+
+test('subagent: model-ID shortening strips a trailing build date - "claude-haiku-4-5-20251001" -> "Haiku 4.5"', () => {
+  const { lines } = runSubagent(JSON.stringify({ tasks: [{ id: 't', model: 'claude-haiku-4-5-20251001' }] }));
+  assert.strictEqual(cleanContent(lines[0].content), 'agent │ Haiku 4.5');
+});
+
+test('subagent: model-ID shortening strips us./anthropic. vendor prefixes', () => {
+  const { lines } = runSubagent(JSON.stringify({ tasks: [{ id: 't', model: 'us.anthropic.claude-opus-5' }] }));
+  assert.strictEqual(cleanContent(lines[0].content), 'agent │ Opus 5');
+});


### PR DESCRIPTION
## What

Adds an opt-in **subagent mode** to `statusline.js`, wiring it into Claude Code's [`subagentStatusLine`](https://code.claude.com/docs/en/statusline) setting so the agent panel shows each running subagent's **model, effort, context usage and token count** — info the main statusline can't surface (its stdin always carries the primary session's model/effort, even when viewing a subagent's conversation).

```json
{
  "subagentStatusLine": {
    "type": "command",
    "command": "node ~/.claude/hooks/statusline.js subagent"
  }
}
```

Result:

<img width="1848" height="417" alt="image" src="https://github.com/user-attachments/assets/f9e5f02f-f974-41e9-82f9-c8ed5451d708" />

## How

- Same single file, second entry point: `process.argv[2] === 'subagent'` branches before any usage/git/todos/cache work — subagent mode parses stdin `tasks[]` and emits one `{"id","content"}` JSON line per task, nothing else.
- Reuses the main line's visual language: `SEGMENT_SEP`, effort colors (`max` red / `ultracode` purple), and the context bar — the used%→bar piece is factored out of `getContextBar` into `renderContextBar` so both surfaces share thresholds; main-line output is byte-identical (existing tests unchanged and passing).
- New `shortenModelId()` for resolved model IDs (`claude-opus-5` → `Opus 5`, `claude-haiku-4-5-20251001` → `Haiku 4.5`), distinct from the display-name `shortenModel()`.
- Every segment past the name is conditional: `model`/`contextWindowSize` are absent until resolved, `effort` is absent when the subagent inherits the session effort (numeric token-budget efforts render as-is). Bad payload → emit nothing, keeping Claude Code's default rows, exit 0.
- Installers untouched (mode is opt-in via settings.json); `scripts/preview.js` untouched (primary line unaffected).

## Sync

- `test/render.test.js`: +10 tests (full task, absent model/effort, numeric effort, bad payload, task without id, model-ID shortening incl. `us.anthropic.` prefix) — 73/73 passing.
- `CLAUDE.md`: new "Subagent mode" section + ad-hoc render command.
- `README.md`: wiring snippet under the manual-install details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subagent statusline rendering with task names, model details, effort, context usage, and token counts.
  * Added support for newline-delimited JSON output for multiple subagent tasks.
  * Added handling for incomplete or malformed task data.

* **Documentation**
  * Documented subagent statusline configuration, input/output formats, rendering behavior, timeouts, and failure handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->