### PR TITLE
fix: wire subagentStatusLine into all installers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp/x"},
 
 # Ad-hoc subagent-row render (subagentStatusLine mode — see below):
 echo '{"tasks":[{"id":"t1","name":"reviewer","model":"claude-opus-5","effort":"max","tokenCount":45200,"contextWindowSize":200000,"startTime":'$(($(date +%s)-252))'}]}' | node statusline.js subagent
-# startTime above is "4m12s ago" in epoch seconds — see the startTime format note below.
+# startTime = 4m12s ago in epoch seconds (format note below).
 ```
 
 Publishing + local-install detail: `docs/DEV.md`.
@@ -40,7 +40,7 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 
 **Timing is load-bearing.** stdin raced against `overallTimeout` (500ms with `ANTHROPIC_API_KEY`, else 1300/1600ms by cache presence); first to fire prints and `exit(0)`. Usage API has its own timeout (1200ms warm / 1500ms cold) and fires only on the fallback path.
 
-**Segment opt-out.** `CTXLINE_DISABLE` comma list parsed once into the `DISABLED` set (trimmed, lowercased). Recognized: `branch`, `effort`, `cost`, `task`, `usage` (H+W). `dir`/`model`/`context` always render; unknown names ignored. Disabling skips the work, not just the output — `usage` means no network/cache/credentials at all.
+**Segment opt-out.** `CTXLINE_DISABLE` comma list parsed once into `DISABLED` (trimmed, lowercased). Recognized: `branch`, `effort`, `cost`, `task`, `usage` (H+W). `dir`/`model`/`context` always render; unknown names ignored. Disabling skips the work, not just the output — `usage` means no network/cache/credentials at all.
 
 **Responsive layout (`layout()`).** Visible width (ANSI stripped) > `COLUMNS - WIDTH_MARGIN` → two lines: line 1 dir/branch + model/effort + `C`; line 2 `H`/`W` + `$` + task. Wraps only when `COLUMNS` is a known positive int and line 2 is non-empty — unknown width, wide terminals, nothing to wrap all stay single-line. `outputFallback()` stays single-line.
 
@@ -57,15 +57,18 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 | scoped weekly | OAuth API only | never arrives via stdin; `getScopedColor` (orange, red ≥90), not the H/W thresholds |
 | task | newest `~/.claude/todos/<sessionId>*-agent-*.json` | `activeForm` of the `in_progress` todo |
 
-**Usage API.** `GET api.anthropic.com/api/oauth/usage`, bearer token + `anthropic-beta: oauth-2025-04-20`. Token from `getCredentials()`: `~/.claude/.credentials.json`, then macOS keychain. API-key users get no usage. `getRawUsage()` resolves `{ fiveHour, weekly, models }` cache-first; `buildUsageBars()` renders all three (`models` a possibly-empty array). `parseScopedLimits(usage)` reads `limits[]` for `kind: 'weekly_scoped'`, label = first initial of `scope.model.display_name` (new model family needs no code change); falls back to legacy flat `seven_day_opus`/`seven_day_sonnet` only when `limits` yields nothing, so neither shape double-counts. Because scoped limits never arrive via stdin, `resolveUsage()` calls `getScopedModels()` even when `H`/`W` came from stdin — capped at one call per `FRESH_TTL_MS`, and a slow/failed call costs only the scoped bars.
+**Usage API.** `GET api.anthropic.com/api/oauth/usage`, bearer token + `anthropic-beta: oauth-2025-04-20`. Token from `getCredentials()`: `~/.claude/.credentials.json`, then macOS keychain. API-key users get no usage.
+- `getRawUsage()` → `{ fiveHour, weekly, models }`, cache-first; `buildUsageBars()` renders all three (`models` possibly empty).
+- `parseScopedLimits(usage)` reads `limits[]` for `kind: 'weekly_scoped'`; label = first initial of `scope.model.display_name` (new model family needs no code change). Legacy flat `seven_day_opus`/`seven_day_sonnet` only when `limits` yields nothing → neither shape double-counts.
+- Scoped limits never arrive via stdin → `resolveUsage()` calls `getScopedModels()` even when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; slow/failed call costs only the scoped bars.
 
-Entry point guarded by `require.main === module` so `test/render.test.js` can `require('../statusline.js')` and unit-test `parseScopedLimits`/`normalizePercentage` — the `/usage` payload shape is the one part stdin can't reach.
+Entry point guarded by `require.main === module` so `test/render.test.js` can `require()` it and unit-test `parseScopedLimits`/`normalizePercentage` — the `/usage` payload shape is the one part stdin can't reach.
 
 **Caches** (both in `~/.claude/cache/`):
-- `usage-cache.json` — raw `{ fiveHour, weekly, models }`, not formatted strings, so old string-format caches are ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10min. Bars re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
-- `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (a render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
+- `usage-cache.json` — raw `{ fiveHour, weekly, models }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10min. Bars re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
+- `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
 
-**Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg, so several scoped bars read as one group while a nearly-spent one still stands out.
+**Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg → several scoped bars read as one group while a nearly-spent one still stands out.
 
 ## Subagent mode (`subagentStatusLine`)
 
@@ -75,20 +78,25 @@ A second entry point in the same file, activated by `process.argv[2] === 'subage
 { "subagentStatusLine": { "type": "command", "command": "node ~/.claude/hooks/statusline.js subagent" } }
 ```
 
-Renders one row per running subagent task in the agent panel. Stdin is `{ tasks: [...], ... }` (base fields like `session_id`/`cwd`/`columns` are present but unused); each task carries `id`, `name`/`description`/`label`, `type`, `status`, `startTime`, `model` (resolved ID, absent until resolved), `effort` (level string or numeric token budget, absent when the subagent inherits the session effort), `contextWindowSize`, `tokenCount`, `tokenSamples`, `cwd`. Stdout is one `{"id","content"}` JSON line per task to override — omitting a task's id keeps its default rendering, an empty `content` hides the row.
+One row per running subagent task in the agent panel.
 
-`startTime`'s format isn't documented upstream and isn't otherwise read in this file, so `formatElapsed()` accepts whatever shows up: a number < `1e12` is treated as epoch-seconds, a larger number as epoch-ms, anything else handed straight to `Date()` (covers an ISO string). Revisit if a real payload ever contradicts this.
+- Stdin: `{ tasks: [...], ... }` (base fields `session_id`/`cwd`/`columns` present but unused). Each task: `id`, `name`/`description`/`label`, `type`, `status`, `startTime`, `model` (resolved ID, absent until resolved), `effort` (level string or numeric token budget, absent when the subagent inherits session effort), `contextWindowSize`, `tokenCount`, `tokenSamples`, `cwd`.
+- Stdout: one `{"id","content"}` JSON line per task to override. Omitted id → default rendering; empty `content` → row hidden.
 
-Row: `name │ Model · effort │ C<used> <bar> │ ⏱ <elapsed>`, built by `renderSubagentTask()`. Reuses the main line's building blocks rather than duplicating them: `SEGMENT_SEP`, `renderContextBar()` (the used%→bar/color part factored out of `getContextBar`, shared by both), `getEffortColor()`. `shortenModelId()` shortens the resolved model *ID* ("claude-opus-5" → "Opus 5", strips `us.`/`anthropic.` prefixes and a trailing `-YYYYMMDD` date) — distinct from `shortenModel()`, which only trims `" context)"` off a display *name*. Every segment past `name` is independently conditional: no `model` → no model/effort segment (effort alone still renders if present); no `effort` → no `· effort` suffix; `tokenCount`/`contextWindowSize` not both finite (or window ≤ 0) → no context bar; `startTime` unparseable → no elapsed segment.
+`startTime`'s format isn't documented upstream and isn't otherwise read in this file, so `formatElapsed()` accepts whatever shows up: number < `1e12` → epoch-seconds, larger → epoch-ms, anything else handed straight to `Date()` (covers an ISO string). Revisit if a real payload contradicts this.
 
-Skips everything main mode does besides stdin parsing — no usage API, no git, no todos, no cache — so there's no `overallTimeout` race against a fetch; `emitSubagent()` just hard-caps the stdin read at `SUBAGENT_TIMEOUT_MS`. A bad/missing payload, or a task whose shape breaks rendering, emits nothing rather than a partial line — default rendering stays for every task in the panel, and the process still exits 0.
+Row: `name │ Model · effort │ C<used> <bar> │ ⏱ <elapsed>`, built by `renderSubagentTask()`. Reuses main-line blocks rather than duplicating: `SEGMENT_SEP`, `renderContextBar()` (used%→bar/color, factored out of `getContextBar`, shared by both), `getEffortColor()`. `shortenModelId()` shortens the resolved model *ID* ("claude-opus-5" → "Opus 5"; strips `us.`/`anthropic.` prefixes and a trailing `-YYYYMMDD` date) — distinct from `shortenModel()`, which only trims `" context)"` off a display *name*.
+
+Every segment past `name` is independently conditional: no `model` → no model/effort segment (effort alone still renders); no `effort` → no `· effort` suffix; `tokenCount`/`contextWindowSize` not both finite (or window ≤ 0) → no context bar; unparseable `startTime` → no elapsed segment.
+
+Skips everything main mode does besides stdin parsing — no usage API, git, todos, cache — so no `overallTimeout` race against a fetch; `emitSubagent()` hard-caps the stdin read at `SUBAGENT_TIMEOUT_MS`. Bad/missing payload, or a task whose shape breaks rendering → emit nothing rather than a partial line: default rendering stays for every task in the panel, process still exits 0.
 
 ## Keep in sync when `statusline.js` changes
 
 `statusline.js` is source of truth; five files mirror the visible line and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
 
 Executable fixtures — stale = CI/release breaks:
-- `scripts/preview.js` — spawns the real `statusline.js` against a seeded `usage-cache.json` + stdin JSON. Cache-shape change → update the seed **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add it to the input object.
+- `scripts/preview.js` — spawns the real `statusline.js` against a seeded `usage-cache.json` + stdin JSON. Cache-shape change → update the seed **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add to the input object. The release body shows `head -n 1` of its output → keep the primary-line `console.log` **first**.
 - `test/render.test.js` — `seedHome()` writes the same cache file (same breakage); assertions pin visible labels/percentages/colors/order. `colors` codes change → update the constants atop the file.
 
 Docs/marketing — stale = silent drift:
@@ -100,17 +108,17 @@ Full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.
 
 Rule of thumb: change to **what the line looks like** → test assertions. Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
 
-Visible contract: field order + `│` separator; `C<used>` with bar; `H<pct>`/`W<pct>` with `↺ <reset>`, no bar; dim `$<cost>` after usage, before task; context thresholds green <50 / yellow <65 / orange <80 / blink-red ≥80; branch + dim `↑N↓M`; effort; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
+Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar; `$<cost>` dim, after usage and before task; `↑N↓M` dim; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
 
 Test harness: `run()` opts `columns` (unset → single line) and `disable` (→ `CTXLINE_DISABLE`); preview's `render()` takes matching params (narrow scenario 40, opt-out scenario `usage,cost`) plus `models` (`[{ label, percentage, resetsInMin }]`) for the scoped-limit scenario. Both clear `COLUMNS`/`CTXLINE_DISABLE` when unset so a dev-env value can't skew output. Git ahead/behind tests need real `git` (skipped if absent) and a fresh HOME per test (isolated `git-cache.json`).
 
 ## Do not touch the installers
 
 Work in `statusline.js` only. Install path is frozen (inherited working from upstream):
-- Don't change behavior of `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name) or wiring a new settings.json entry that a shipped `statusline.js` feature already depends on (e.g. `subagentStatusLine` — see below).
+- Don't change behavior of `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name) or wiring a settings.json entry a shipped `statusline.js` feature already depends on (e.g. `subagentStatusLine`).
 - `npx ctxline-claude` → `bin/install.js` installs silently, no prompts. Keep it so.
-- All three installers write both `statusLine` and `subagentStatusLine` to `settings.json`, pointing at the same hook file (`subagentStatusLine` appends a space + `subagent` to the command). Hook path is written quoted — the command runs through a shell, so an unquoted home dir with spaces splits into two args. Adding a new entry point in `statusline.js` means wiring it into all three, not just documenting the snippet.
-- Uninstall path exists: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our `statusLine`/`subagentStatusLine` from `settings.json` (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command — only printed manual-removal instructions, which must list both keys too.
+- All three write both `statusLine` and `subagentStatusLine`, same hook file (`subagentStatusLine` appends a space + `subagent`). Path written quoted — command runs through a shell, so an unquoted home dir with spaces splits into two args. New entry point → wire into all three, not just document the snippet.
+- Uninstall: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our `statusLine`/`subagentStatusLine` (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command — only printed manual-removal instructions, which must list both keys too.
 - Don't reintroduce a "Full vs Lite" prompt or `statusline-lite.js` (deleted upstream `846e10e`). Only as a deliberate real feature.
 
 ## Distribution
@@ -119,11 +127,4 @@ Work in `statusline.js` only. Install path is frozen (inherited working from ups
 
 ## Releasing
 
-Automated — **don't `npm publish` by hand.** `package.json` `version` is the single source of truth.
-
-1. Bump `version` in `package.json` (commit on `main`).
-2. GitHub → Actions → **Release** (`.github/workflows/release.yml`) → Run workflow.
-
-Workflow reads version from `package.json`, runs tests, publishes (`NPM_TOKEN` secret), tags `v<version>`, creates the release with rendered preview + auto notes + source zip. npm rejects an existing version and the tag step refuses a duplicate, so step 1 is required.
-
-**Release preview is always a single line.** `preview.js` prints several scenarios for the CI sync-check, but the release body shows only the primary line — the workflow takes `head -n 1` ("Render statusline preview" step). Keep the primary-line `console.log` as the **first** thing `preview.js` prints, and never drop `head -n 1`.
+Owner-triggered, manual: bump `version` in `package.json` on `main`, then run the **Release** workflow (`.github/workflows/release.yml`), which publishes from that version. Never `npm publish` by hand; never bump the version unasked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Test harness: `run()` opts `columns` (unset → single line) and `disable` (→ 
 Work in `statusline.js` only. Install path is frozen (inherited working from upstream):
 - Don't change behavior of `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name) or wiring a new settings.json entry that a shipped `statusline.js` feature already depends on (e.g. `subagentStatusLine` — see below).
 - `npx ctxline-claude` → `bin/install.js` installs silently, no prompts. Keep it so.
-- All three installers write both `statusLine` and `subagentStatusLine` to `settings.json`, pointing at the same hook file (`subagentStatusLine` appends ` subagent` to the command). Adding a new entry point in `statusline.js` means wiring it into all three, not just documenting the snippet.
+- All three installers write both `statusLine` and `subagentStatusLine` to `settings.json`, pointing at the same hook file (`subagentStatusLine` appends a space + `subagent` to the command). Hook path is written quoted — the command runs through a shell, so an unquoted home dir with spaces splits into two args. Adding a new entry point in `statusline.js` means wiring it into all three, not just documenting the snippet.
 - Uninstall path exists: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our `statusLine`/`subagentStatusLine` from `settings.json` (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command — only printed manual-removal instructions, which must list both keys too.
 - Don't reintroduce a "Full vs Lite" prompt or `statusline-lite.js` (deleted upstream `846e10e`). Only as a deliberate real feature.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,10 @@ Test harness: `run()` opts `columns` (unset → single line) and `disable` (→ 
 ## Do not touch the installers
 
 Work in `statusline.js` only. Install path is frozen (inherited working from upstream):
-- Don't change behavior of `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name).
+- Don't change behavior of `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name) or wiring a new settings.json entry that a shipped `statusline.js` feature already depends on (e.g. `subagentStatusLine` — see below).
 - `npx ctxline-claude` → `bin/install.js` installs silently, no prompts. Keep it so.
-- Uninstall path exists: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our `statusLine` from `settings.json` (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install.
+- All three installers write both `statusLine` and `subagentStatusLine` to `settings.json`, pointing at the same hook file (`subagentStatusLine` appends ` subagent` to the command). Adding a new entry point in `statusline.js` means wiring it into all three, not just documenting the snippet.
+- Uninstall path exists: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our `statusLine`/`subagentStatusLine` from `settings.json` (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command — only printed manual-removal instructions, which must list both keys too.
 - Don't reintroduce a "Full vs Lite" prompt or `statusline-lite.js` (deleted upstream `846e10e`). Only as a deliberate real feature.
 
 ## Distribution

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ chmod +x ~/.claude/hooks/statusline.js
 }
 ```
 
+Note: the effort level only shows on a subagent row when that task has its own effort override — Claude Code doesn't currently report effort for a subagent that just inherits the session's setting.
+
 </details>
 
 ## Update

--- a/bin/install.js
+++ b/bin/install.js
@@ -62,14 +62,17 @@ if (fs.existsSync(settingsFile)) {
   }
 }
 
+// Path is quoted — the command runs through a shell, so an unquoted home dir with spaces would split.
+const commandPath = scriptDest.replace(/\\/g, '/');
+
 settings.statusLine = {
   type: 'command',
-  command: `node ${scriptDest.replace(/\\/g, '/')}`
+  command: `node "${commandPath}"`
 };
 
 settings.subagentStatusLine = {
   type: 'command',
-  command: `node ${scriptDest.replace(/\\/g, '/')} subagent`
+  command: `node "${commandPath}" subagent`
 };
 
 fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2));

--- a/bin/install.js
+++ b/bin/install.js
@@ -67,6 +67,11 @@ settings.statusLine = {
   command: `node ${scriptDest.replace(/\\/g, '/')}`
 };
 
+settings.subagentStatusLine = {
+  type: 'command',
+  command: `node ${scriptDest.replace(/\\/g, '/')} subagent`
+};
+
 fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
 console.log(`${green}✓ Updated settings.json${reset}`);
 
@@ -86,26 +91,38 @@ function runUninstall() {
     return;
   }
 
-  // 1. Remove our statusLine entry from settings.json (preserving everything else)
+  // 1. Remove our statusLine/subagentStatusLine entries from settings.json (preserving everything else)
   if (fs.existsSync(settingsFile)) {
     try {
       const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
       const command = ((settings.statusLine && settings.statusLine.command) || '').replace(/\\/g, '/');
+      const subagentCommand = ((settings.subagentStatusLine && settings.subagentStatusLine.command) || '').replace(/\\/g, '/');
       // Match our hook path only (covers absolute + manual `~` installs), not any statusline.js.
       const isOurs = command.includes('/.claude/hooks/statusline.js');
+      const isSubagentOurs = subagentCommand.includes('/.claude/hooks/statusline.js');
+      let changed = false;
       if (settings.statusLine && isOurs) {
-        const backup = `${settingsFile}.backup.${Date.now()}`;
-        fs.copyFileSync(settingsFile, backup);
         delete settings.statusLine;
-        fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
-        console.log(`${green}✓ Removed statusLine from settings.json (backup: ${path.basename(backup)})${reset}`);
+        changed = true;
       } else if (settings.statusLine) {
         console.log(`${yellow}! settings.json has a different statusLine — leaving it untouched.${reset}`);
       } else {
         console.log(`${green}✓ No statusLine entry in settings.json${reset}`);
       }
+      if (settings.subagentStatusLine && isSubagentOurs) {
+        delete settings.subagentStatusLine;
+        changed = true;
+      } else if (settings.subagentStatusLine) {
+        console.log(`${yellow}! settings.json has a different subagentStatusLine — leaving it untouched.${reset}`);
+      }
+      if (changed) {
+        const backup = `${settingsFile}.backup.${Date.now()}`;
+        fs.copyFileSync(settingsFile, backup);
+        fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+        console.log(`${green}✓ Removed statusLine/subagentStatusLine from settings.json (backup: ${path.basename(backup)})${reset}`);
+      }
     } catch (e) {
-      console.log(`${red}✗ Could not parse settings.json — remove the "statusLine" block manually.${reset}`);
+      console.log(`${red}✗ Could not parse settings.json — remove the "statusLine"/"subagentStatusLine" blocks manually.${reset}`);
     }
   }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -412,6 +412,7 @@
       <div class="line subrow"><span class="dim">○&nbsp;</span><span>architecture-review</span><span class="sep">│</span><span>Opus&nbsp;5<span class="effort-max">&nbsp;· max</span></span><span class="sep">│</span><span class="context-yellow"><span class="val">C51</span><span class="bar"><i class="on"></i><i class="on"></i><i class="on"></i><i></i><i></i><i></i></span></span><span class="sep">│</span><span class="dim">⏱ 4m12s</span></div>
       <div class="line subrow"><span class="dim">○&nbsp;</span><span>test-coverage</span><span class="sep">│</span><span>Sonnet&nbsp;5<span class="dim">&nbsp;· high</span></span><span class="sep">│</span><span class="val">C36</span><span class="bar"><i class="on"></i><i class="on"></i><i></i><i></i><i></i><i></i></span><span class="sep">│</span><span class="dim">⏱ 1m48s</span></div>
     </div>
+    <p class="insp-hint">Effort only shows when a subagent overrides it — not when it just inherits the session's setting.</p>
   </section>
 
   <!-- HOW IT WORKS -->

--- a/install.ps1
+++ b/install.ps1
@@ -63,11 +63,11 @@ if (Test-Path $SETTINGS_FILE) {
 $commandPath = "$HOOKS_DIR\$SCRIPT_NAME" -replace '\\', '/'
 $settings.statusLine = @{
     type = "command"
-    command = "node $commandPath"
+    command = "node `"$commandPath`""
 }
 $settings.subagentStatusLine = @{
     type = "command"
-    command = "node $commandPath subagent"
+    command = "node `"$commandPath`" subagent"
 }
 
 # Write back to file

--- a/install.ps1
+++ b/install.ps1
@@ -59,11 +59,15 @@ if (Test-Path $SETTINGS_FILE) {
     }
 }
 
-# Update statusLine setting (use forward slashes for cross-platform compatibility)
+# Update statusLine/subagentStatusLine settings (use forward slashes for cross-platform compatibility)
 $commandPath = "$HOOKS_DIR\$SCRIPT_NAME" -replace '\\', '/'
 $settings.statusLine = @{
     type = "command"
     command = "node $commandPath"
+}
+$settings.subagentStatusLine = @{
+    type = "command"
+    command = "node $commandPath subagent"
 }
 
 # Write back to file
@@ -82,7 +86,7 @@ Write-Host "  2. Your statusline should now be active!"
 Write-Host ""
 Write-Host "To uninstall:"
 Write-Host "  - Remove ~/.claude/hooks/$SCRIPT_NAME"
-Write-Host "  - Remove the 'statusLine' section from ~/.claude/settings.json"
+Write-Host "  - Remove the 'statusLine' and 'subagentStatusLine' sections from ~/.claude/settings.json"
 Write-Host ""
 Write-Host "For help, visit: https://github.com/MithunWijayasiri/ctxline-claude"
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,10 @@ if [ ! -f "$SETTINGS_FILE" ]; then
   "statusLine": {
     "type": "command",
     "command": "node $HOOKS_DIR/$SCRIPT_NAME"
+  },
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "node $HOOKS_DIR/$SCRIPT_NAME subagent"
   }
 }
 EOF
@@ -90,6 +94,11 @@ settings.statusLine = {
     command: 'node $HOOKS_DIR/$SCRIPT_NAME'
 };
 
+settings.subagentStatusLine = {
+    type: 'command',
+    command: 'node $HOOKS_DIR/$SCRIPT_NAME subagent'
+};
+
 fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
 console.log('Settings updated successfully');
 EOF
@@ -104,6 +113,10 @@ EOF
         echo '  "statusLine": {'
         echo '    "type": "command",'
         echo "    \"command\": \"node $HOOKS_DIR/$SCRIPT_NAME\""
+        echo '  },'
+        echo '  "subagentStatusLine": {'
+        echo '    "type": "command",'
+        echo "    \"command\": \"node $HOOKS_DIR/$SCRIPT_NAME subagent\""
         echo '  }'
     fi
 fi
@@ -120,7 +133,7 @@ echo "  2. Your statusline should now be active!"
 echo ""
 echo "To uninstall:"
 echo "  - Remove ~/.claude/hooks/$SCRIPT_NAME"
-echo "  - Remove the 'statusLine' section from ~/.claude/settings.json"
+echo "  - Remove the 'statusLine' and 'subagentStatusLine' sections from ~/.claude/settings.json"
 echo ""
 echo "For help, visit: https://github.com/MithunWijayasiri/ctxline-claude"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -65,11 +65,11 @@ if [ ! -f "$SETTINGS_FILE" ]; then
 {
   "statusLine": {
     "type": "command",
-    "command": "node $HOOKS_DIR/$SCRIPT_NAME"
+    "command": "node \"$HOOKS_DIR/$SCRIPT_NAME\""
   },
   "subagentStatusLine": {
     "type": "command",
-    "command": "node $HOOKS_DIR/$SCRIPT_NAME subagent"
+    "command": "node \"$HOOKS_DIR/$SCRIPT_NAME\" subagent"
   }
 }
 EOF
@@ -91,12 +91,12 @@ try {
 
 settings.statusLine = {
     type: 'command',
-    command: 'node $HOOKS_DIR/$SCRIPT_NAME'
+    command: 'node "$HOOKS_DIR/$SCRIPT_NAME"'
 };
 
 settings.subagentStatusLine = {
     type: 'command',
-    command: 'node $HOOKS_DIR/$SCRIPT_NAME subagent'
+    command: 'node "$HOOKS_DIR/$SCRIPT_NAME" subagent'
 };
 
 fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
@@ -112,11 +112,11 @@ EOF
         echo ""
         echo '  "statusLine": {'
         echo '    "type": "command",'
-        echo "    \"command\": \"node $HOOKS_DIR/$SCRIPT_NAME\""
+        echo "    \"command\": \"node \\\"$HOOKS_DIR/$SCRIPT_NAME\\\"\""
         echo '  },'
         echo '  "subagentStatusLine": {'
         echo '    "type": "command",'
-        echo "    \"command\": \"node $HOOKS_DIR/$SCRIPT_NAME subagent\""
+        echo "    \"command\": \"node \\\"$HOOKS_DIR/$SCRIPT_NAME\\\" subagent\""
         echo '  }'
     fi
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctxline-claude",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A customizable statusline for Claude Code that tracks context usage and session limits",
   "bin": {
     "ctxline-claude": "bin/install.js"

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -183,3 +183,34 @@ console.log('  ' + render({
 // Segment opt-out: CTXLINE_DISABLE hides segments (dir/model/context always render).
 console.log('\nSegment opt-out (CTXLINE_DISABLE=usage,cost):');
 console.log('  ' + render({ ...base, effort: 'high', disable: 'usage,cost' }));
+
+// Subagent panel (subagentStatusLine mode): separate entry point (`node statusline.js
+// subagent`), separate stdin shape ({ tasks: [...] }), no cache/HOME seeding needed since
+// it reads only stdin. Two tasks cover both branches: full row, and no-effort (inherited).
+function renderSubagentPanel(tasks) {
+  const res = spawnSync(process.execPath, [SCRIPT, 'subagent'], {
+    input: JSON.stringify({ tasks }),
+    encoding: 'utf8',
+    timeout: 5000
+  });
+  if (res.error) throw res.error;
+  if (res.status !== 0) {
+    throw new Error(`statusline.js subagent exited with ${res.status}\n${res.stderr || ''}`);
+  }
+  const byId = new Map(
+    (res.stdout || '').trim().split('\n').filter(Boolean).map(line => {
+      const o = JSON.parse(line);
+      return [o.id, o.content];
+    })
+  );
+  return tasks.map(t => byId.get(t.id) || `(default rendering: ${t.id})`);
+}
+
+console.log('\nSubagent panel (2 running tasks):');
+const nowSecPanel = Math.floor(Date.now() / 1000);
+for (const line of renderSubagentPanel([
+  { id: 't1', name: 'reviewer', model: 'claude-opus-5', effort: 'high', tokenCount: 45200, contextWindowSize: 200000, startTime: nowSecPanel - 252 },
+  { id: 't2', name: 'explorer', model: 'claude-sonnet-5', tokenCount: 12400, contextWindowSize: 200000, startTime: nowSecPanel - 15 }
+])) {
+  console.log('  ' + line);
+}


### PR DESCRIPTION
v1.6.0's subagent-panel rows never rendered - installers only wrote settings.statusLine, never subagentStatusLine, so statusline.js's subagent mode was correct but never wired up on install.

- bin/install.js, install.sh, install.ps1 - write + remove subagentStatusLine alongside statusLine.
- package.json - 1.6.0 -> 1.6.1.
- CLAUDE.md - documents the installer-sync requirement.
- scripts/preview.js - adds a "Subagent panel (2 running tasks)" scenario so the release preview shows the feature too.
- README.md / docs/index.html - note that a subagent's effort only shows when the task has its own override, not when it inherits the session's setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installers now configure subagent status-line display alongside the standard status line.
  * Subagent effort is shown when a task has its own effort setting.
  * Added a preview scenario for subagent status-line output.

* **Bug Fixes**
  * Uninstallation now safely removes either status-line configuration while preserving unrelated settings and creating backups only when needed.

* **Documentation**
  * Updated installation, uninstallation, and subagent effort guidance.

* **Chores**
  * Updated the package version to 1.6.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->