### PR TITLE
docs: correct drifted format contract (#32)

### DIFF
--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -14,7 +14,7 @@ description: Change the statusline's visible design — layout, segment format, 
 | `statusline.js` | render logic — source of truth | `getContextBar`, `buildUsageBar`, `buildUsageBars`, `formatAheadBehind`, `getCostSegment`, `layout`, `outputStatus`, `outputFallback` |
 | `test/render.test.js` | assertions on labels / `NN%` / colors / order | match new label regexes (e.g. `/C\d+ /`, `/H\d+\b/`); ANSI const block near top |
 | `scripts/preview.js` | seed + render check | cache seed shape, `render()` params (`columns`, `disable`); **primary `console.log` stays FIRST line** (release takes `head -n 1`) |
-| `docs/assets/preview.svg` | marketing SVG (README/site) | the single statusline `<text>` element (`<tspan>` runs) |
+| `docs/assets/preview.svg` | marketing SVG (README/site) | 12 `<text>` elements (main statusline + subagent rows) with `<tspan>` runs |
 | `docs/index.html` | landing page | hero mock (`.term .line`, ~line 323), inspector `SIGNALS[]` array (~line 446), `.term` color classes (~line 129) |
 | `CLAUDE.md` | spec | format diagram (top), segment-source table, "visible contract" paragraph |
 
@@ -29,7 +29,7 @@ dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 �
 - Labels fused with percent: `C`=context, `H`=5h, `W`=7d, `<initial>`=model-scoped weekly limit (Fable → `F`, label derived from `scope.model.display_name` in `parseScopedLimits` — never hardcode a model list).
 - Context keeps a bar; `H`/`W`/scoped are label + `↺ countdown`, no bar.
 - Labels live INSIDE the builder functions (`getContextBar`/`buildUsageBar`), not as prefixes in `outputStatus`. `outputStatus`/`outputFallback` push segments verbatim.
-- `↑N↓M` is appended to the branch string (dim), not a separate segment. Zero side omitted.
+- `↑N↓M` is appended to the branch string (↑ green / ↓ red), not a separate segment. Zero side omitted.
 - `$<cost>` is dim, sits after usage and before task.
 - Consts: `BAR_WIDTH` 6 (bar cells), `SEGMENT_SEP` `' │ '`, `MAX_BRANCH_LEN` 24, `WIDTH_MARGIN` 0.
 
@@ -64,7 +64,7 @@ Effort: only top two highlighted — `max` red, `ultracode` purple; rest dim.
 
 SVG/HTML palette (`docs/assets/preview.svg`, `docs/index.html`): green `#3fb950` (svg) / `#7ec77f` (`--green` html) · orange `#f0883e` · empty cell `#2d333b` · dim `#7d8590` · separator `#30363d` · dir/accent `#d97757`.
 
-Divergence to know: the site colors ahead/behind (`.ahead` green, `.behind` `#f85149`), while `statusline.js` renders `↑N↓M` dim.
+Ahead/behind: both the site (`.ahead` green / `.behind` `#f85149`) and `statusline.js` (`formatAheadBehind` green ↑ / red ↓) color `↑N↓M`; `docs/assets/preview.svg` uses `#3fb950`/`#f85149` matching the code.
 
 ## Gotchas
 

--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -23,7 +23,7 @@ After edits: `npm test` + `npm run preview`. Both must pass + look right.
 ## Current format
 
 ```text
-dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 ↺ 4h21m │ W31 ↺ 2d14h │ F86 ↺ 2d14h │ $44.21 │ task
+dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 ↺ 4h20m │ W31 ↺ 2d13h │ F86 ↺ 2d13h │ $44.21 │ task
 ```
 
 - Labels fused with percent: `C`=context, `H`=5h, `W`=7d, `<initial>`=model-scoped weekly limit (Fable → `F`, label derived from `scope.model.display_name` in `parseScopedLimits` — never hardcode a model list).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ Entry point guarded by `require.main === module` so `test/render.test.js` can `r
 
 **Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg → several scoped bars read as one group while a nearly-spent one still stands out.
 
+**Deliberately duplicated, do not merge:** the two caches (`git-cache.json` / `usage-cache.json` via `readGitCache`/`writeGitCache` + `getGitAheadBehind` vs `readCachedUsage`/`setCachedUsage` + `getRawUsage`) and the two duration formatters (`buildUsageBar`'s countdown vs `formatElapsed`) each have only two callers with differing validators / units / refresh policies (git 5s/60s vs usage 30s/10m; countdown vs elapsed). A shared `withCache`/`formatDuration` would move complexity into parameters, not reduce it — revisit only on a third caller.
+
 ## Subagent mode (`subagentStatusLine`)
 
 A second entry point in the same file, activated by `process.argv[2] === 'subagent'` — wired in `settings.json` as a separate command from `statusLine`:
@@ -108,7 +110,7 @@ Full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.
 
 Rule of thumb: change to **what the line looks like** → test assertions. Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
 
-Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar; `$<cost>` dim, after usage and before task; `↑N↓M` dim; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
+Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar; `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
 
 Test harness: `run()` opts `columns` (unset → single line) and `disable` (→ `CTXLINE_DISABLE`); preview's `render()` takes matching params (narrow scenario 40, opt-out scenario `usage,cost`) plus `models` (`[{ label, percentage, resetsInMin }]`) for the scoped-limit scenario. Both clear `COLUMNS`/`CTXLINE_DISABLE` when unset so a dev-env value can't skew output. Git ahead/behind tests need real `git` (skipped if absent) and a fresh HOME per test (isolated `git-cache.json`).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -354,9 +354,9 @@
         <span class="val">C45</span>
         <span class="bar"><i class="on"></i><i class="on"></i><i class="on"></i><i></i><i></i><i></i></span>
         <span class="sep">│</span>
-        <span class="val">H14</span>&nbsp;<span class="dim">↺ 4h21m</span>
+        <span class="val">H14</span>&nbsp;<span class="dim">↺ 4h20m</span>
         <span class="sep">│</span>
-        <span class="val">W31</span>&nbsp;<span class="dim">↺ 2d14h</span>
+        <span class="val">W31</span>&nbsp;<span class="dim">↺ 2d13h</span>
         <span class="sep">│</span>
         <span class="dim">$44.21</span>
       </div>


### PR DESCRIPTION
Fixes #32 — docs-only, no `statusline.js` change.

- `CLAUDE.md:111` — `↑N↓M dim` → green ↑ / red ↓ (matches `formatAheadBehind()` + `preview.svg` `#3fb950`/`#f85149`)
- `SKILL.md:32` — drop `(dim)` from `↑N↓M`
- `SKILL.md:67` — delete inverted “site colors … while statusline renders dim” line
- `SKILL.md:17` — `single <text>` → 12 `<text>` elements with `<tspan>` runs
- `docs/index.html` — hero `4h21m/2d14h` → `4h20m/2d13h` to match inspector `SIGNALS[]`
- `CLAUDE.md` — record that the two caches + two duration formatters are deliberately duplicated (second caller, differing validators/TTLs/units — no `withCache`)

`npm test` 76/76 + `npm run preview` unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated statusline documentation to reflect green ahead and red behind branch indicators.
  * Clarified the intended formatting behavior for cached values and durations.
  * Updated example reset timers to display `4h20m` and `2d13h`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->