### PR TITLE
refactor: single guarded stdin reader (#33)

### DIFF
--- a/statusline.js
+++ b/statusline.js
@@ -249,6 +249,11 @@ function getContextBar(remaining) {
   return renderContextBar(used);
 }
 
+// "model" or "model · effort" (colored). Shared by the main line and subagent rows.
+function renderModelEffort(model, effort) {
+  return effort ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}` : model;
+}
+
 // Render a compact usage segment from raw data: "<label><pct> ↺ <countdown>"
 // (e.g. "H81 ↺ 2h21m") — no bar. Called on every read (live or cached) so the reset
 // countdown is always recomputed from resetsAt rather than frozen at fetch time.
@@ -638,7 +643,7 @@ function outputStatus(data, usage) {
     line1.push(branch
       ? `${dirname} ${colors.dim}⎇ ${branch}${colors.reset}${sync ? ' ' + sync : ''}`
       : dirname);
-    line1.push(effort ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}` : model);
+    line1.push(renderModelEffort(model, effort));
     line1.push(contextBar);
 
     const line2 = [];
@@ -682,7 +687,6 @@ function resolveUsage(data, callback) {
   getUsageWithCache(callback);
 }
 
-// Process with timeout
 // Parse the accumulated stdin into a payload object, or null if empty/unparseable.
 function parseInput(input) {
   if (!input || input.length === 0) return null;
@@ -691,6 +695,29 @@ function parseInput(input) {
   } catch (e) {
     return null;
   }
+}
+
+// Accumulate stdin then call fn(input) exactly once, on whichever fires first:
+// timeout, 'end', or 'error' (an unhandled stdin error would otherwise throw,
+// breaking the never-throw contract). Shared by both entry points below, which
+// differ only in timeoutMs.
+function readStdinThen(timeoutMs, fn) {
+  let input = '';
+  let finished = false;
+
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    clearTimeout(timeout);
+    fn(input);
+  };
+
+  const timeout = setTimeout(finish, timeoutMs);
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => input += chunk);
+  process.stdin.on('end', finish);
+  process.stdin.on('error', finish);
 }
 
 // Resolve usage for `data` (preferring stdin rate_limits), then render and exit.
@@ -733,9 +760,7 @@ function renderSubagentTask(t) {
   // effort absent = subagent inherits the session effort; show model alone then.
   const effort = t.effort != null ? String(t.effort) : '';
   if (model) {
-    parts.push(effort
-      ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}`
-      : model);
+    parts.push(renderModelEffort(model, effort));
   } else if (effort) {
     parts.push(`${getEffortColor(effort)}${effort}${colors.reset}`);
   }
@@ -777,51 +802,17 @@ function emitSubagent(data) {
 // directly (the /usage response shape is the easiest thing here to get wrong, and it
 // can't be reached through stdin). Running the script normally is unchanged.
 if (require.main === module) {
-  if (process.argv[2] === 'subagent') {
-    if (process.stdin.isTTY) {
-      emitSubagent(null);
-    } else {
-      let input = '';
-      let finished = false;
+  const isSubagent = process.argv[2] === 'subagent';
+  const finish = isSubagent ? emitSubagent : emit;
 
-      // Single guarded exit shared by all three triggers: timeout, stdin 'end', and
-      // stdin 'error' (which can fire before 'end' and would otherwise throw unhandled,
-      // breaking the never-throw contract). Whatever accumulated so far gets rendered.
-      const finish = () => {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeout);
-        emitSubagent(parseInput(input));
-      };
-
-      const timeout = setTimeout(finish, SUBAGENT_TIMEOUT_MS);
-
-      process.stdin.setEncoding('utf8');
-      process.stdin.on('data', chunk => input += chunk);
-      process.stdin.on('end', finish);
-      process.stdin.on('error', finish);
-    }
-  } else if (process.stdin.isTTY) {
-    emit(null);
+  if (process.stdin.isTTY) {
+    finish(null);
   } else {
-    let input = '';
-    let timeoutReached = false;
-
-    const overallTimeout = IS_API_KEY ? 500 : (fs.existsSync(USAGE_CACHE_FILE) ? 1300 : 1600);
-
-    const timeout = setTimeout(() => {
-      timeoutReached = true;
-      emit(parseInput(input));
-    }, overallTimeout);
-
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => input += chunk);
-    process.stdin.on('end', () => {
-      if (timeoutReached) return;
-      clearTimeout(timeout);
-      emit(parseInput(input));
-    });
+    const timeoutMs = isSubagent
+      ? SUBAGENT_TIMEOUT_MS
+      : (IS_API_KEY ? 500 : (fs.existsSync(USAGE_CACHE_FILE) ? 1300 : 1600));
+    readStdinThen(timeoutMs, (input) => finish(parseInput(input)));
   }
 } else {
-  module.exports = { parseScopedLimits, normalizePercentage };
+  module.exports = { parseScopedLimits, normalizePercentage, readStdinThen };
 }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -5,6 +5,7 @@
 const { test, after } = require('node:test');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
+const { EventEmitter } = require('node:events');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -396,7 +397,7 @@ test('stdin rate_limits -> 5h/7d render with no cache and no creds', () => {
 // these in a `limits` array; they never appear on stdin, so they always come from the
 // cache/API path. parseScopedLimits is exercised directly against the real payload shape.
 
-const { parseScopedLimits } = require('../statusline.js');
+const { parseScopedLimits, readStdinThen } = require('../statusline.js');
 
 // A trimmed copy of a real GET /api/oauth/usage response: the legacy seven_day_<model>
 // keys are all null, and the live scoped limit lives in `limits`.
@@ -473,6 +474,48 @@ test('no scoped limits -> nothing extra renders', () => {
   assert.match(clean, /H24\b/);
   assert.match(clean, /W41\b/);
   assert.ok(!/\bF\d+/.test(clean), 'no F bar when the account reports no scoped limit');
+});
+
+// readStdinThen is the single guarded reader shared by both entry points (main and
+// subagent). A stdin error used to throw unhandled on the main path only — this
+// exercises that exact reader against a fake stdin, since a real stdin error can't
+// be forced reliably through a spawned child's pipe.
+test('readStdinThen finishes exactly once on a stdin error, never throws', () => {
+  const original = Object.getOwnPropertyDescriptor(process, 'stdin');
+  const fake = new EventEmitter();
+  fake.setEncoding = () => {};
+  Object.defineProperty(process, 'stdin', { value: fake, configurable: true });
+  try {
+    let calls = 0;
+    let result;
+    assert.doesNotThrow(() => {
+      readStdinThen(1000, (input) => { calls++; result = input; });
+      fake.emit('data', '{"partial":true');
+      fake.emit('error', new Error('EPIPE'));
+      fake.emit('end'); // must not double-fire after 'error' already finished
+    });
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(result, '{"partial":true');
+  } finally {
+    Object.defineProperty(process, 'stdin', original);
+  }
+});
+
+test('readStdinThen finishes on timeout with whatever was read so far', () => {
+  const original = Object.getOwnPropertyDescriptor(process, 'stdin');
+  const fake = new EventEmitter();
+  fake.setEncoding = () => {};
+  Object.defineProperty(process, 'stdin', { value: fake, configurable: true });
+  try {
+    return new Promise((resolve) => {
+      readStdinThen(10, (input) => {
+        assert.strictEqual(input, '');
+        resolve();
+      });
+    });
+  } finally {
+    Object.defineProperty(process, 'stdin', original);
+  }
 });
 
 // Rendering: scoped bars come from the cache, including on the stdin fast path.

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -509,9 +509,10 @@ test('readStdinThen finishes on timeout with whatever was read so far', () => {
   try {
     return new Promise((resolve) => {
       readStdinThen(10, (input) => {
-        assert.strictEqual(input, '');
+        assert.strictEqual(input, '{"partial":true');
         resolve();
       });
+      fake.emit('data', '{"partial":true');
     });
   } finally {
     Object.defineProperty(process, 'stdin', original);


### PR DESCRIPTION
## Summary
- Extract `readStdinThen(timeoutMs, fn)` — one guarded reader (timeout/`end`/`error`) shared by both entry points; the main path was missing the `error` handler the subagent path had, so a stdin error there would throw unhandled.
- Dedupe the `model · effort` template into `renderModelEffort()`, next to `renderContextBar`.
- Add tests for `readStdinThen`'s error and timeout paths.

Fixes #33

## Test plan
- [x] `npm test` — 78/78 passing (2 new)
- [x] `npm run preview` — output unchanged
- [x] `statusline.js` net -9 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status display consistency for models and effort levels across primary and subagent rows.
  * Improved handling of standard input timeouts, completion, and errors.
  * Prevented input errors from causing unexpected failures or duplicate processing.

* **Tests**
  * Added coverage for input errors, timeout completion, accumulated input, and single-callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->