### PR TITLE
refactor: usage pipeline down to one raw shape, two fewer wrappers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,16 +53,18 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 | model · effort | stdin | `(1M context)` → `(1M)`; effort ranks low<medium<high<xhigh<max<ultracode, only `max` (red) + `ultracode` (purple) highlighted, rest dim |
 | `C` | stdin `remaining_percentage` | always available |
 | `$` | stdin `cost.total_cost_usd`, no network/cache | `Number.isFinite`-guarded; client-side estimate at API pricing — for subscription users not actual billing |
-| `H` / `W` | stdin `rate_limits` via `buildUsageFromStdin()`, else `getUsageWithCache()` → OAuth API | `rate_limits` exists only for Claude.ai Pro/Max **after the first API response** — absent at cold start and for API-key users, hence the fallback |
+| `H` / `W` | stdin `rate_limits` via `buildUsageFromStdin()`, else `getRawUsage()` → OAuth API | `rate_limits` exists only for Claude.ai Pro/Max **after the first API response** — absent at cold start and for API-key users, hence the fallback |
 | scoped weekly | OAuth API only | never arrives via stdin; `getScopedColor` (orange, red ≥90), not the H/W thresholds |
 | task | newest `~/.claude/todos/<sessionId>*-agent-*.json` | `activeForm` of the `in_progress` todo |
 
 **Usage API.** `GET api.anthropic.com/api/oauth/usage`, bearer token + `anthropic-beta: oauth-2025-04-20`. Token from `getCredentials()`: `~/.claude/.credentials.json`, then macOS keychain. API-key users get no usage.
+- `parseUsagePayload(body)` — pure, no fs/network — turns a raw `/usage` response body into `{ fiveHour, weekly, models }`; `null` on unparseable JSON or a missing/non-finite `five_hour` utilization. `getApiUsage()` calls it, then owns only credentials/socket/timeout/cache-write.
+- `buildUsageFromStdin()` returns the same `{ fiveHour, weekly, models }` shape (`models` always `[]` — stdin never carries scoped limits), so both adapters feed `buildUsageBars(raw)` directly — one positional object, not three.
 - `getRawUsage()` → `{ fiveHour, weekly, models }`, cache-first; `buildUsageBars()` renders all three (`models` possibly empty).
 - `parseScopedLimits(usage)` reads `limits[]` for `kind: 'weekly_scoped'`; label = first initial of `scope.model.display_name` (new model family needs no code change). Legacy flat `seven_day_opus`/`seven_day_sonnet` only when `limits` yields nothing → neither shape double-counts.
-- Scoped limits never arrive via stdin → `resolveUsage()` calls `getScopedModels()` even when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; slow/failed call costs only the scoped bars.
+- Scoped limits never arrive via stdin → `resolveUsage()` calls `getRawUsage()` for the model-scoped bars even when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; slow/failed call costs only the scoped bars.
 
-Entry point guarded by `require.main === module` so `test/render.test.js` can `require()` it and call the exported pure functions directly instead of spawning: `renderStatusLine`/`renderSubagentTask` (format/colour-band/segment-order/wrap assertions) and `parseScopedLimits`/`normalizePercentage` (the `/usage` payload shape is the one part stdin can't reach) — plus `readStdinThen` for the stdin-error test.
+Entry point guarded by `require.main === module` so `test/render.test.js` can `require()` it and call the exported pure functions directly instead of spawning: `renderStatusLine`/`renderSubagentTask` (format/colour-band/segment-order/wrap assertions) and `parseScopedLimits`/`parseUsagePayload`/`normalizePercentage` (the `/usage` payload shape is the one part stdin can't reach) — plus `readStdinThen` for the stdin-error test.
 
 `outputStatus` is a ~3-line writer: `collectFacts(data)` gathers everything that touches fs/child_process/env (git branch + ahead/behind, the in-progress task, `COLUMNS`), then the pure `renderStatusLine(data, facts, usage)` formats, wrapped in a try/catch that falls back to `Status unavailable`. `outputFallback` calls the same `renderStatusLine` with a static, git/task-free `facts` object (`cols: undefined` keeps it single-line, matching the always-single-line fallback contract). `layout()` takes `cols` as a parameter rather than reading `COLUMNS` itself, so it and `renderStatusLine` have no side effects.
 

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -168,7 +168,8 @@ console.log('  ' + render({
 }));
 
 // Combined: H/W from stdin, scoped bars still from cache — resolveUsage() calls
-// getScopedModels() even when stdin covered H/W, so all three must render together.
+// getRawUsage() for the scoped bars even when stdin covered H/W, so all three must
+// render together.
 console.log('\nStdin rate_limits + cached model-scoped limit:');
 console.log('  ' + render({
   ...base,

--- a/statusline.js
+++ b/statusline.js
@@ -295,12 +295,15 @@ const LEGACY_MODEL_WEEKLY_KEYS = [
   { key: 'seven_day_sonnet', label: 'S' }
 ];
 
-// Build the usage segments from raw entries. fiveHour/weekly are { percentage, resetsAt }
-// or null/absent; models is an array of { label, percentage, resetsAt } (possibly empty).
-// Returns { current, weekly, models } — the first two rendered strings or null, models a
-// (possibly empty) array of rendered strings. Scoped bars use getScopedColor instead of the
-// H/W thresholds, so the full threshold palette stays exclusive to H/W.
-function buildUsageBars(fiveHour, weekly, models) {
+// Build the usage segments from a raw { fiveHour, weekly, models } object — the shared
+// shape both buildUsageFromStdin and parseUsagePayload return. fiveHour/weekly are
+// { percentage, resetsAt } or null/absent; models is an array of { label, percentage,
+// resetsAt } (possibly empty). Returns { current, weekly, models } — the first two
+// rendered strings or null, models a (possibly empty) array of rendered strings. Scoped
+// bars use getScopedColor instead of the H/W thresholds, so the full threshold palette
+// stays exclusive to H/W.
+function buildUsageBars(raw) {
+  const { fiveHour, weekly, models } = raw || {};
   return {
     current: fiveHour ? buildUsageBar('H', fiveHour.percentage, fiveHour.resetsAt) : null,
     weekly: weekly ? buildUsageBar('W', weekly.percentage, weekly.resetsAt) : null,
@@ -349,9 +352,10 @@ function parseScopedLimits(usage) {
 // Build usage bars from stdin `rate_limits` (Claude.ai Pro/Max, present only after the
 // first API response of a session). Same data as the OAuth usage API, so reading it here
 // skips the network/credentials/cache path entirely. `resets_at` is a Unix epoch in
-// SECONDS (not ISO) — ×1000 before Date. Returns raw { fiveHour, weekly } entries, or null
-// when rate_limits is absent or the required five_hour segment is unusable (caller falls
-// back). Model-scoped weekly limits are never present here — see LEGACY_MODEL_WEEKLY_KEYS.
+// SECONDS (not ISO) — ×1000 before Date. Returns raw { fiveHour, weekly, models } — same
+// shape as parseUsagePayload — or null when rate_limits is absent or the required
+// five_hour segment is unusable (caller falls back). models is always [] here: model-scoped
+// weekly limits are never present in stdin — see LEGACY_MODEL_WEEKLY_KEYS.
 function buildUsageFromStdin(data) {
   const rl = data?.rate_limits;
   if (!rl) return null;
@@ -374,7 +378,29 @@ function buildUsageFromStdin(data) {
 
   const fiveHour = toEntry(rl.five_hour);
   if (!fiveHour) return null;          // five_hour is the required bar
-  return { fiveHour, weekly: toEntry(rl.seven_day) };
+  return { fiveHour, weekly: toEntry(rl.seven_day), models: [] };
+}
+
+// Parse a raw /usage API response body into { fiveHour, weekly, models } — same shape as
+// buildUsageFromStdin — or null on unparseable JSON or a missing/non-finite five_hour
+// utilization (that bar is required). Normalizes utilization first so a missing/non-finite
+// value omits a bar instead of rendering "NaN%". Pure — no fs/network — so it's unit
+// testable directly, unlike getApiUsage which needs a live socket.
+function parseUsagePayload(body) {
+  try {
+    const usage = JSON.parse(body);
+    const fivePct = usage?.five_hour ? normalizePercentage(usage.five_hour.utilization) : null;
+    if (fivePct == null) return null;
+
+    const fiveHour = { percentage: fivePct, resetsAt: usage.five_hour.resets_at || null };
+    const weeklyPct = usage.seven_day ? normalizePercentage(usage.seven_day.utilization) : null;
+    const weekly = weeklyPct != null ? { percentage: weeklyPct, resetsAt: usage.seven_day.resets_at || null } : null;
+    const models = parseScopedLimits(usage);
+
+    return { fiveHour, weekly, models };
+  } catch (e) {
+    return null;
+  }
 }
 
 // Validate a single usage entry ({ percentage, resetsAt }). Returns true only for a
@@ -488,37 +514,10 @@ function getApiUsage(callback) {
 
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
-        try {
-          const usage = JSON.parse(data);
-
-          // 5-hour session usage is required; weekly (seven_day) is rendered when present.
-          // Normalize utilization first so a missing/non-finite value omits the bar
-          // instead of rendering "NaN%" or an out-of-range percentage.
-          const fivePct = usage.five_hour ? normalizePercentage(usage.five_hour.utilization) : null;
-          if (fivePct != null) {
-            const fiveHour = {
-              percentage: fivePct,
-              resetsAt: usage.five_hour.resets_at || null
-            };
-            const weeklyPct = usage.seven_day ? normalizePercentage(usage.seven_day.utilization) : null;
-            const weekly = weeklyPct != null ? {
-              percentage: weeklyPct,
-              resetsAt: usage.seven_day.resets_at || null
-            } : null;
-
-            // Model-scoped weekly limits, rendered only when the account reports them.
-            const models = parseScopedLimits(usage);
-
-            // Cache the raw data (shared across sessions); callers render from it.
-            const resolved = { fiveHour, weekly, models };
-            setCachedUsage(resolved);
-            callback(resolved);
-          } else {
-            callback(null);
-          }
-        } catch (e) {
-          callback(null);
-        }
+        const resolved = parseUsagePayload(data);
+        // Cache the raw data (shared across sessions); callers render from it.
+        if (resolved) setCachedUsage(resolved);
+        callback(resolved);
       });
     });
 
@@ -554,20 +553,6 @@ function getRawUsage(callback) {
       callback(null);
     }
   });
-}
-
-// Get usage, cache-first, rendered.
-function getUsageWithCache(callback) {
-  getRawUsage((data) => {
-    callback(data ? buildUsageBars(data.fiveHour, data.weekly, data.models) : null);
-  });
-}
-
-// Model-scoped weekly limits only, cache-first. Used alongside the stdin H/W bars, which
-// can't carry them. Falls back to the stale cache and finally to [] so a failed or slow
-// call costs the scoped bars but never the bars stdin already gave us.
-function getScopedModels(callback) {
-  getRawUsage((data) => callback(data?.models || []));
 }
 
 // Session cost from stdin `cost.total_cost_usd` (USD float, computed client-side by
@@ -697,11 +682,13 @@ function resolveUsage(data, callback) {
     // stdin covers H and W with no network. Model-scoped weekly limits only exist in the
     // API payload, so they come from the cache — refreshed on the same TTL as every other
     // usage read, which keeps at most one call per FRESH_TTL_MS regardless of render rate.
-    return getScopedModels((models) => {
-      callback(buildUsageBars(fromStdin.fiveHour, fromStdin.weekly, models));
+    // Falls back to the stale cache and finally to [] so a failed or slow call costs only
+    // the scoped bars, never the H/W bars stdin already gave us.
+    return getRawUsage((cached) => {
+      callback(buildUsageBars({ ...fromStdin, models: cached?.models || [] }));
     });
   }
-  getUsageWithCache(callback);
+  getRawUsage((raw) => callback(raw ? buildUsageBars(raw) : null));
 }
 
 // Parse the accumulated stdin into a payload object, or null if empty/unparseable.
@@ -831,5 +818,5 @@ if (require.main === module) {
     readStdinThen(timeoutMs, (input) => finish(parseInput(input)));
   }
 } else {
-  module.exports = { parseScopedLimits, normalizePercentage, readStdinThen, renderStatusLine, renderSubagentTask };
+  module.exports = { parseScopedLimits, parseUsagePayload, normalizePercentage, readStdinThen, renderStatusLine, renderSubagentTask };
 }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -182,7 +182,7 @@ const BLINK = '\x1b[5m';
 // child process. What's left spawned: git-branch/ahead-behind detection (real .git dir +
 // subprocess), the usage cache/API pipeline, CTXLINE_DISABLE env-parsing (module-load-time
 // state, needs a fresh process per value), and the execution-contract tests below.
-const { parseScopedLimits, readStdinThen, renderStatusLine, renderSubagentTask } = require('../statusline.js');
+const { parseScopedLimits, parseUsagePayload, readStdinThen, renderStatusLine, renderSubagentTask } = require('../statusline.js');
 
 // Same shape as fixture()'s stdin JSON, but as a plain object (no JSON round-trip needed
 // for a direct call).
@@ -511,6 +511,47 @@ test('no scoped limits -> nothing extra renders', () => {
   assert.match(clean, /H24\b/);
   assert.match(clean, /W41\b/);
   assert.ok(!/\bF\d+/.test(clean), 'no F bar when the account reports no scoped limit');
+});
+
+// parseUsagePayload is the pure adapter lifted out of getApiUsage's response closure —
+// getApiUsage itself runs in zero tests (needs a live socket), so this is the only unit
+// coverage for the half of the pipeline that breaks first on a payload change. Returns the
+// same { fiveHour, weekly, models } shape as buildUsageFromStdin.
+
+test('parseUsagePayload parses a real /usage response body into { fiveHour, weekly, models }', () => {
+  const parsed = parseUsagePayload(JSON.stringify(usagePayload()));
+  assert.deepStrictEqual(parsed, {
+    fiveHour: { percentage: 43, resetsAt: '2026-08-02T17:00:00+00:00' },
+    weekly: { percentage: 63, resetsAt: '2026-08-05T13:00:00+00:00' },
+    models: [{ label: 'F', percentage: 86, resetsAt: '2026-08-05T13:00:00+00:00' }]
+  });
+});
+
+test('parseUsagePayload returns null when five_hour is missing', () => {
+  assert.strictEqual(parseUsagePayload(JSON.stringify({ seven_day: { utilization: 50 } })), null);
+});
+
+test('parseUsagePayload returns null when five_hour.utilization is non-finite', () => {
+  assert.strictEqual(parseUsagePayload(JSON.stringify({ five_hour: { utilization: 'NaN' } })), null);
+});
+
+test('parseUsagePayload omits weekly when seven_day is absent', () => {
+  const parsed = parseUsagePayload(JSON.stringify({ five_hour: { utilization: 43 } }));
+  assert.deepStrictEqual(parsed, { fiveHour: { percentage: 43, resetsAt: null }, weekly: null, models: [] });
+});
+
+test('parseUsagePayload falls back to legacy seven_day_<model> keys for models', () => {
+  const legacy = {
+    five_hour: { utilization: 43 },
+    seven_day_opus: { utilization: 77, resets_at: '2026-08-05T13:00:00+00:00' },
+    seven_day_sonnet: null
+  };
+  const parsed = parseUsagePayload(JSON.stringify(legacy));
+  assert.deepStrictEqual(parsed.models, [{ label: 'O', percentage: 77, resetsAt: '2026-08-05T13:00:00+00:00' }]);
+});
+
+test('parseUsagePayload returns null on unparseable JSON instead of throwing', () => {
+  assert.strictEqual(parseUsagePayload('not json'), null);
 });
 
 // readStdinThen is the single guarded reader shared by both entry points (main and


### PR DESCRIPTION
## Summary
- Lift `parseUsagePayload(body)` out of `getApiUsage`'s response closure — pure, exported, unit-tested independently of the live socket.
- `buildUsageFromStdin` and `parseUsagePayload` now both return `{ fiveHour, weekly, models }`; `buildUsageBars(raw)` takes one object instead of three positionals.
- Inline and delete `getUsageWithCache` and `getScopedModels` (one-statement, one-caller wrappers) into `resolveUsage`.
- Update `CLAUDE.md` and `scripts/preview.js` comments to match.

Fixes #35

## Test plan
- [x] `npm test` — 85/85 (6 new `parseUsagePayload` tests: missing `five_hour`, non-finite utilization, absent `seven_day`, legacy flat keys, unparseable JSON)
- [x] `npm run preview` — output unchanged
- [x] stdin path still ≤1 API call per `FRESH_TTL_MS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Usage displays now combine five-hour, weekly, and model-specific rate limits more consistently.
  * Stdin-based usage reporting retains account-wide limits while incorporating available model-specific limits.
  * API usage data is parsed more reliably, including support for missing weekly data and invalid responses.

* **Documentation**
  * Updated usage documentation to explain stdin behavior, supported limits, normalized usage data, and testing helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->