### PR TITLE
test: own the cache format, share one fixture, generate preview.svg

### DIFF
--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -13,12 +13,12 @@ description: Change the statusline's visible design — layout, segment format, 
 |---|---|---|
 | `statusline.js` | render logic — source of truth | `getContextBar`, `buildUsageBar`, `buildUsageBars`, `formatAheadBehind`, `getCostSegment`, `layout`, `collectFacts`, `renderStatusLine`, `outputStatus`, `outputFallback` |
 | `test/render.test.js` | assertions on labels / `NN%` / colors / order | match new label regexes (e.g. `/C\d+ /`, `/H\d+\b/`); ANSI const block near top |
-| `scripts/preview.js` | seed + render check | cache seed shape, `render()` params (`columns`, `disable`); **primary `console.log` stays FIRST line** (release takes `head -n 1`) |
-| `docs/assets/preview.svg` | marketing SVG (README/site) | 12 `<text>` elements (main statusline + subagent rows) with `<tspan>` runs |
-| `docs/index.html` | landing page | hero mock (`.term .line`, ~line 323), inspector `SIGNALS[]` array (~line 446), `.term` color classes (~line 129) |
+| `scripts/preview.js` | seed + render check | cache seed data (via `test/fixture.js`'s `seedUsageCache`), `render()` params (`columns`, `disable`); **primary `console.log` stays FIRST line** (release takes `head -n 1`) |
+| `docs/assets/preview.svg` | marketing SVG (README/site) | 2 of its 12 `<text>` elements (main statusline + subagent row) are **generated**, not hand-edited — run `npm run preview:svg` after any output-shape change; the other 10 (window chrome, prompt lines, bullets) stay hand-authored |
+| `docs/index.html` | landing page | hero mock (`.term .line`) and subagent rows are checked by `test/docs-drift.test.js` (fails `npm test` on drift) — update its synthetic scenario if you change what they depict; inspector `SIGNALS[]` array and `.term` color classes are NOT checked, hand-verify |
 | `CLAUDE.md` | spec | format diagram (top), segment-source table, "visible contract" paragraph |
 
-After edits: `npm test` + `npm run preview`. Both must pass + look right.
+After edits: `npm test` + `npm run preview` + `npm run preview:svg`. All must pass + look right.
 
 ## Current format
 
@@ -72,6 +72,7 @@ Ahead/behind: both the site (`.ahead` green / `.behind` `#f85149`) and `statusli
 - Scoped bars come only from the `/usage` API payload, never stdin — preview/tests exercise them through the seeded cache, so a scoped-bar restyle needs the cache seed updated too.
 - Don't touch installers (`bin/install.js`, `install.sh`, `install.ps1`) — frozen. No Full/Lite prompt or second file (deleted upstream).
 - README has no sample line — leave it.
+- New ANSI color in `colors` (top of `statusline.js`) → add it to `scripts/preview-svg.js`'s `ANSI_HEX` table too, or `npm run preview:svg` silently falls back to the default text color for it.
 
 ## Render to verify (ANSI in terminal)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ No build, no lint. Edit `statusline.js` directly.
 ```bash
 npm test           # render tests (Node built-in runner, zero deps)
 npm run preview    # sample lines for every color band + fallback
+npm run preview:svg # regenerate docs/assets/preview.svg's statusline tspans from a real render
 npm pack --dry-run # preview what publishes
 # Don't publish by hand — see Releasing.
 
@@ -101,13 +102,15 @@ Skips everything main mode does besides stdin parsing — no usage API, git, tod
 
 `statusline.js` is source of truth; five files mirror the visible line and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
 
-Executable fixtures — stale = CI/release breaks:
-- `scripts/preview.js` — spawns the real `statusline.js` against a seeded `usage-cache.json` + stdin JSON. Cache-shape change → update the seed **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add to the input object. The release body shows `head -n 1` of its output → keep the primary-line `console.log` **first**.
-- `test/render.test.js` — `seedHome()` writes the same cache file (same breakage); assertions pin visible labels/percentages/colors/order. `colors` codes change → update the constants atop the file.
+`test/fixture.js` — shared by both: fake-HOME construction, `usage-cache.json` seeding (via `statusline.js`'s own exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, and spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
 
-Docs/marketing — stale = silent drift:
-- `docs/assets/preview.svg` — the single statusline `<text>` element (`<tspan>` runs); shown in README + site.
-- `docs/index.html` — hero mock (`.term .line`), inspector `SIGNALS[]`, `.term` color classes.
+Executable fixtures — stale = CI/release breaks:
+- `scripts/preview.js` — spawns the real `statusline.js` via `test/fixture.js` against a seeded cache + stdin JSON. Cache-shape change → update the seed data passed to `seedUsageCache` **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add to the input object. The release body shows `head -n 1` of its output → keep the primary-line `console.log` **first**.
+- `test/render.test.js` — same fixture, same breakage; assertions pin visible labels/percentages/colors/order. `colors` codes change → update the constants atop the file.
+
+Docs/marketing — no longer silent, both auto-checked:
+- `docs/assets/preview.svg` — the statusline `<text>` elements' `<tspan>` runs; shown in README + site. Generated, not hand-edited: `npm run preview:svg` (`scripts/preview-svg.js`) renders the real ANSI output for the same fixed scenario and rewrites just those tspans (ANSI SGR → hex, via its own `ANSI_HEX` table); window chrome, prompt lines, and the "○ " running-task bullet stay hand-authored. Run it after any change that would shift this scenario's output (colors, thresholds, format).
+- `docs/index.html` — hero mock (`.term .line`) and the subagent-panel rows are asserted against a real `renderStatusLine()`/`renderSubagentTask()` call by `test/docs-drift.test.js` (reconstructs the mock's visible text from its markup, byte-compares). A mismatch fails `npm test`, not just a future changelog. Inspector `SIGNALS[]` and `.term` color classes are still unchecked — hand-verify those.
 - `CLAUDE.md` — format diagram (top), segment-source table, visible contract below.
 
 Full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.

--- a/docs/assets/preview.svg
+++ b/docs/assets/preview.svg
@@ -36,13 +36,13 @@
     <line x1="0" y1="326" x2="1280" y2="326" stroke="#20262e" stroke-width="1"></line>
 
 
-    <text x="28" y="354" font-size="14"><tspan fill="#d97757" font-weight="700">my-project</tspan><tspan fill="#7d8590"> ⎇ main </tspan><tspan fill="#3fb950">↑2</tspan><tspan fill="#f85149">↓1</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Opus 4.8 (1M)</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">C45 ███</tspan><tspan fill="#2d333b">░░░</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#f0883e">H81</tspan><tspan fill="#7d8590"> ↺ 2h21m</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">W31</tspan><tspan fill="#7d8590"> ↺ 2d14h</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">$44.21</tspan></text>
+    <text x="28" y="354" font-size="14"><tspan fill="#d97757" font-weight="700">my-project </tspan><tspan fill="#7d8590">⎇ main</tspan><tspan fill="#c9d1d9"> </tspan><tspan fill="#3fb950">↑2</tspan><tspan fill="#f85149">↓1</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Opus 4.8 (1M)</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">C45 ███</tspan><tspan fill="#2d333b">░░░</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#f0883e">H81</tspan><tspan fill="#7d8590"> ↺ 2h20m</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#3fb950">W31</tspan><tspan fill="#7d8590"> ↺ 2d13h</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">$44.21</tspan></text>
 
     <text x="28" y="379" font-size="13"><tspan fill="#f4bf4f">⏵⏵ auto mode on</tspan><tspan fill="#7d8590"> (shift+tab to cycle) · </tspan><tspan fill="#58a6ff">←</tspan><tspan fill="#7d8590"> for agents</tspan></text>
 
 
     <text x="28" y="411" font-size="13"><tspan fill="#c9d1d9">● main</tspan></text>
-    <text x="28" y="435" font-size="13"><tspan fill="#7d8590">○ </tspan><tspan fill="#c9d1d9">Task 1: code-review</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Fable 5</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#f0883e">C68 ████</tspan><tspan fill="#2d333b">░░</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">⏱ 6m48s</tspan></text>
+    <text x="28" y="435" font-size="13"><tspan fill="#7d8590">○ </tspan><tspan fill="#c9d1d9">Task 1: code-review</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#c9d1d9">Fable 5</tspan><tspan fill="#7d8590"> · high</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#f0883e">C68 ████</tspan><tspan fill="#2d333b">░░</tspan><tspan fill="#30363d"> │ </tspan><tspan fill="#7d8590">⏱ 6m49s</tspan></text>
   </g>
 
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "test": "node --test",
-    "preview": "node scripts/preview.js"
+    "preview": "node scripts/preview.js",
+    "preview:svg": "node scripts/preview-svg.js"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/preview-svg.js
+++ b/scripts/preview-svg.js
@@ -1,0 +1,182 @@
+// Regenerates the two statusline <tspan> runs inside docs/assets/preview.svg from a real
+// render of statusline.js, so the marketing SVG can't silently drift from the code the way a
+// hand-transcribed one did (#32). Hand-authored terminal chrome -- window dots, prompt text,
+// the "Nebulizing…" status, the "○ " running-task bullet -- is left untouched; only the
+// tspan runs inside the two statusline <text> elements are replaced.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  makeHome, seedCredentials, seedUsageCache, seedFakeRepo, seedDivergedRepo, spawnMain, spawnSubagent
+} = require('../test/fixture.js');
+
+const SVG_PATH = path.join(__dirname, '..', 'docs', 'assets', 'preview.svg');
+
+// ANSI SGR code -> hex, tuned to read against this SVG's GitHub-dark palette. Yellow/purple
+// never occur in the two scenarios below but are mapped for completeness so a future
+// scenario tweak (e.g. a yellow-band usage %) doesn't need a code change here too.
+const ANSI_HEX = {
+  '32': '#3fb950',        // green
+  '33': '#e3b341',        // yellow (matches docs/index.html's .context-yellow)
+  '31': '#f85149',        // red
+  '38;5;208': '#f0883e',  // orange
+  '38;5;135': '#bc8cff',  // purple
+  '2': '#7d8590'          // dim
+};
+const DEFAULT_HEX = '#c9d1d9';   // plain (no escape) text
+const SEP_HEX = '#30363d';       // ' │ ' segment separator, de-emphasized vs. plain text
+const BAR_EMPTY_HEX = '#2d333b'; // unfilled '░' portion of a context/usage bar
+
+function esc(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Split "...███░░░" on the filled/unfilled boundary so '█' and '░' get their own tspans --
+// the SVG always renders the empty tail in a fixed dark gray, distinct from how a real
+// terminal (one color for the whole bar) renders it.
+function splitBar(text) {
+  const m = text.match(/^([^█░]*█+)(░+.*)$/);
+  return m ? [m[1], m[2]] : null;
+}
+
+// Parse one ANSI-colored line into [{ text, hex, bold? }] runs. `firstPlain`, if given,
+// re-styles the first uncolored run (used for the directory name's brand treatment below --
+// real ANSI carries no color for it, so that distinction is a deliberate rendering choice
+// here, not something recoverable from the escape codes themselves).
+function ansiToRuns(line, { firstPlain } = {}) {
+  const runs = [];
+  let currentHex = null; // null = no color active (plain/default text)
+  let sawFirstPlain = false;
+  let lastIndex = 0;
+
+  const pushColored = (text, hex) => {
+    if (!text) return;
+    const bar = splitBar(text);
+    if (bar) {
+      runs.push({ text: bar[0], hex });
+      runs.push({ text: bar[1], hex: BAR_EMPTY_HEX });
+    } else {
+      runs.push({ text, hex });
+    }
+  };
+
+  // SEGMENT_SEP (' │ ') carries no escape of its own, so it can end up fused with adjacent
+  // plain text into one flush (e.g. "reset} │ Opus 4.8" -- no escape between '│' and 'Opus').
+  // Split it back out before assigning a color to what's left.
+  const pushPlain = (text) => {
+    const bits = text.split(' │ ');
+    bits.forEach((bit, i) => {
+      if (i > 0) runs.push({ text: ' │ ', hex: SEP_HEX });
+      if (!bit) return;
+      let hex = DEFAULT_HEX;
+      let bold = false;
+      if (!sawFirstPlain) {
+        if (firstPlain) { hex = firstPlain.hex; bold = !!firstPlain.bold; }
+        sawFirstPlain = true;
+      }
+      runs.push({ text: bit, hex, bold });
+    });
+  };
+
+  const flush = (end) => {
+    if (end <= lastIndex) return;
+    const text = line.slice(lastIndex, end);
+    if (currentHex == null) pushPlain(text);
+    else pushColored(text, currentHex);
+  };
+
+  const re = /\x1b\[([0-9;]*)m/g;
+  let match;
+  while ((match = re.exec(line)) !== null) {
+    flush(match.index);
+    const code = match[1];
+    if (code === '' || code === '0') currentHex = null;
+    else if (code !== '5') currentHex = ANSI_HEX[code] ?? currentHex; // '5' = blink, no hex of its own
+    lastIndex = re.lastIndex;
+  }
+  flush(line.length);
+  return runs;
+}
+
+function runsToTspans(runs) {
+  return runs.map(r => {
+    const attrs = `fill="${r.hex}"` + (r.bold ? ' font-weight="700"' : '');
+    return `<tspan ${attrs}>${esc(r.text)}</tspan>`;
+  }).join('');
+}
+
+// Same scenario docs/assets/preview.svg has always shown -- regenerating from a real render
+// should reproduce it exactly, just from code instead of by hand.
+function renderPrimaryLine() {
+  const home = makeHome();
+  seedCredentials(home);
+  seedUsageCache(home, {
+    fiveHour: { percentage: 81, resetsAt: new Date(Date.now() + (2 * 60 + 21) * 60000).toISOString() },
+    weekly: { percentage: 31, resetsAt: new Date(Date.now() + (2 * 24 * 60 + 14 * 60) * 60000).toISOString() }
+  });
+  const projectDir = path.join(home, 'my-project');
+  fs.mkdirSync(projectDir, { recursive: true });
+  try {
+    seedDivergedRepo(projectDir, { ahead: 2, behind: 1, branch: 'main' });
+  } catch (e) {
+    seedFakeRepo(projectDir, 'main');
+  }
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  delete env.ANTHROPIC_API_KEY;
+  delete env.COLUMNS;
+  delete env.CTXLINE_DISABLE;
+  const res = spawnMain(JSON.stringify({
+    model: { display_name: 'Opus 4.8 (1M context)' },
+    workspace: { current_dir: projectDir },
+    session_id: 'preview-svg',
+    context_window: { remaining_percentage: 55 }, // used 45 -> "C45"
+    effort: { level: 'high' },
+    cost: { total_cost_usd: 44.21 }
+  }), env);
+  fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  if (res.error) throw res.error;
+  if (res.status !== 0) throw new Error(`statusline.js exited with ${res.status}\n${res.stderr || ''}`);
+  return (res.stdout || '').trim();
+}
+
+function renderSubagentLine() {
+  const res = spawnSubagent(JSON.stringify({
+    tasks: [{
+      id: 't1', name: 'Task 1: code-review', model: 'claude-fable-5', effort: 'high',
+      tokenCount: 68000, contextWindowSize: 100000,
+      // Targets "6m48s" but formatElapsed() re-reads the clock after the setup above runs
+      // (mkdtemp, git spawns) -- a run landing just past a second boundary can render one
+      // second later than this. Harmless jitter, not a bug; re-run if the diff bothers you.
+      startTime: Math.floor(Date.now() / 1000) - (6 * 60 + 48)
+    }]
+  }));
+  if (res.error) throw res.error;
+  if (res.status !== 0) throw new Error(`statusline.js subagent exited with ${res.status}\n${res.stderr || ''}`);
+  const { content } = JSON.parse((res.stdout || '').trim());
+  return content;
+}
+
+function replaceTextContent(svg, openTag, tspans) {
+  const start = svg.indexOf(openTag);
+  if (start === -1) throw new Error(`preview.svg: couldn't find ${openTag}`);
+  const contentStart = start + openTag.length;
+  const contentEnd = svg.indexOf('</text>', contentStart);
+  if (contentEnd === -1) throw new Error(`preview.svg: unterminated <text> after ${openTag}`);
+  return svg.slice(0, contentStart) + tspans + svg.slice(contentEnd);
+}
+
+let svg = fs.readFileSync(SVG_PATH, 'utf8');
+
+const primaryTspans = runsToTspans(
+  ansiToRuns(renderPrimaryLine(), { firstPlain: { hex: '#d97757', bold: true } })
+);
+svg = replaceTextContent(svg, '<text x="28" y="354" font-size="14">', primaryTspans);
+
+// The "○ " bullet is docs/index.html-style chrome marking a running task, hand-authored
+// here too -- kept as-is, only the real render's tspans are appended after it.
+const bulletTspan = '<tspan fill="#7d8590">○ </tspan>';
+const subagentTspans = bulletTspan + runsToTspans(ansiToRuns(renderSubagentLine()));
+svg = replaceTextContent(svg, '<text x="28" y="435" font-size="13">', subagentTspans);
+
+fs.writeFileSync(SVG_PATH, svg);
+console.log('docs/assets/preview.svg regenerated from a real render.');

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -5,72 +5,55 @@
 // (+ a tokenless credentials file) in a throwaway HOME, so the real statusline.js
 // renders the usage segment from cache without any network call.
 
-const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
+const {
+  makeHome, seedCredentials, seedUsageCache, seedFakeRepo, seedDivergedRepo, spawnMain, spawnSubagent
+} = require('../test/fixture.js');
 
-const SCRIPT = path.join(__dirname, '..', 'statusline.js');
-const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-preview-'));
-process.on('exit', () => fs.rmSync(TMP, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
+// makeHome() creates each scenario's home independently (os.tmpdir()-rooted, not nested
+// under a shared parent) -- track them here for one cleanup pass on exit.
+const HOMES = [];
+process.on('exit', () => {
+  for (const home of HOMES) {
+    fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+});
 
-// Build a real diverged git repo in `projectDir` so statusline.js renders ↑N↓M.
-// Best-effort: returns true on success, false if git is unavailable (caller falls back
-// to a fake .git/HEAD so the line — and the release body — still render).
+// Build a real diverged git repo (ahead 2, behind 1) in `projectDir` so statusline.js
+// renders ↑2↓1. Best-effort: returns true on success, false if git is unavailable (caller
+// falls back to a fake .git/HEAD so the line — and the release body — still render).
 function setupDivergedRepo(projectDir, branch) {
   try {
-    const g = (args) => spawnSync('git', args, { cwd: projectDir, encoding: 'utf8' });
     fs.mkdirSync(projectDir, { recursive: true });
-    if (g(['init', '-q']).status !== 0) return false;
-    const commit = (tag) => {
-      fs.writeFileSync(path.join(projectDir, 'f-' + tag), tag);
-      g(['add', '-A']); g(['commit', '-q', '-m', tag]);
-    };
-    g(['config', 'user.email', 't@t']); g(['config', 'user.name', 'preview']);
-    g(['config', 'commit.gpgsign', 'false']);
-    g(['config', 'remote.origin.url', '.']);
-    g(['config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*']);
-    commit('base');
-    g(['branch', '-M', branch]);                              // force the displayed branch name
-    const baseSha = g(['rev-parse', 'HEAD']).stdout.trim();
-    commit('up0');                                            // upstream +1 -> behind 1
-    const upstreamSha = g(['rev-parse', 'HEAD']).stdout.trim();
-    g(['update-ref', 'refs/remotes/origin/' + branch, upstreamSha]);
-    g(['config', 'branch.' + branch + '.remote', 'origin']);
-    g(['config', 'branch.' + branch + '.merge', 'refs/heads/' + branch]);
-    g(['reset', '--hard', '-q', baseSha]);
-    commit('local0'); commit('local1');                      // local +2 -> ahead 2
-    return g(['rev-parse', '--git-dir']).status === 0;
+    seedDivergedRepo(projectDir, { ahead: 2, behind: 1, branch });
+    return true;
   } catch (e) {
     return false;
   }
 }
 
 function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, models, branch, effort, rateLimits, cost, columns, diverged, disable }) {
-  const home = fs.mkdtempSync(path.join(TMP, 'home-'));
-  const cacheDir = path.join(home, '.claude', 'cache');
-  fs.mkdirSync(cacheDir, { recursive: true });
+  const home = makeHome();
+  HOMES.push(home);
   // Only H/W bypass the cache: with rateLimits and no models, seed neither creds nor cache,
   // proving that path needs no network. Model-scoped bars never arrive via stdin, so seed a
   // fresh cache whenever `models` is set — rateLimits or not (statusline.js reads both).
   if (!rateLimits || models) {
-    fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), '{}'); // no token -> no network
-    fs.writeFileSync(path.join(cacheDir, 'usage-cache.json'), JSON.stringify({
-      timestamp: Date.now(),                                  // fresh -> cache-first renders it
-      data: {
-        fiveHour: { percentage: current, resetsAt: new Date(Date.now() + currentResetsInMin * 60000).toISOString() },
-        weekly: { percentage: weekly, resetsAt: new Date(Date.now() + weeklyResetsInMin * 60000).toISOString() },
-        // Model-scoped weekly limits. The cache holds the already-derived label, so seed it
-        // directly; statusline.js only derives F-from-Fable when parsing a live /usage payload.
-        ...(models ? {
-          models: models.map(m => ({
-            label: m.label,
-            percentage: m.percentage,
-            resetsAt: new Date(Date.now() + m.resetsInMin * 60000).toISOString()
-          }))
-        } : {})
-      }
-    }));
+    seedCredentials(home); // no token -> no network
+    seedUsageCache(home, {
+      fiveHour: { percentage: current, resetsAt: new Date(Date.now() + currentResetsInMin * 60000).toISOString() },
+      weekly: { percentage: weekly, resetsAt: new Date(Date.now() + weeklyResetsInMin * 60000).toISOString() },
+      // Model-scoped weekly limits. The cache holds the already-derived label, so seed it
+      // directly; statusline.js only derives F-from-Fable when parsing a live /usage payload.
+      ...(models ? {
+        models: models.map(m => ({
+          label: m.label,
+          percentage: m.percentage,
+          resetsAt: new Date(Date.now() + m.resetsInMin * 60000).toISOString()
+        }))
+      } : {})
+    }); // fresh timestamp (default) -> cache-first renders it
   }
 
   // Real on-disk dir so the branch segment renders. `diverged` builds a real repo with an
@@ -78,8 +61,7 @@ function render({ dir, model, remaining, current, currentResetsInMin, weekly, we
   // reads it directly. basename(currentDir) keeps the displayed dir name.
   const projectDir = path.join(home, dir);
   if (!(diverged && setupDivergedRepo(projectDir, branch))) {
-    fs.mkdirSync(path.join(projectDir, '.git'), { recursive: true });
-    fs.writeFileSync(path.join(projectDir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
+    seedFakeRepo(projectDir, branch);
   }
 
   const env = { ...process.env, HOME: home, USERPROFILE: home };
@@ -91,20 +73,15 @@ function render({ dir, model, remaining, current, currentResetsInMin, weekly, we
   if (disable != null) env.CTXLINE_DISABLE = disable;       // segment opt-out scenario
   else delete env.CTXLINE_DISABLE;
 
-  const res = spawnSync(process.execPath, [SCRIPT], {
-    input: JSON.stringify({
-      model: { display_name: model },
-      workspace: { current_dir: projectDir },
-      session_id: 'preview',
-      context_window: { remaining_percentage: remaining },
-      effort: { level: effort },
-      ...(cost != null ? { cost: { total_cost_usd: cost } } : {}),
-      ...(rateLimits ? { rate_limits: rateLimits } : {})
-    }),
-    encoding: 'utf8',
-    timeout: 5000,
-    env
-  });
+  const res = spawnMain(JSON.stringify({
+    model: { display_name: model },
+    workspace: { current_dir: projectDir },
+    session_id: 'preview',
+    context_window: { remaining_percentage: remaining },
+    effort: { level: effort },
+    ...(cost != null ? { cost: { total_cost_usd: cost } } : {}),
+    ...(rateLimits ? { rate_limits: rateLimits } : {})
+  }), env);
 
   if (res.error) throw res.error;
   if (res.status !== 0) {
@@ -189,11 +166,7 @@ console.log('  ' + render({ ...base, effort: 'high', disable: 'usage,cost' }));
 // subagent`), separate stdin shape ({ tasks: [...] }), no cache/HOME seeding needed since
 // it reads only stdin. Two tasks cover both branches: full row, and no-effort (inherited).
 function renderSubagentPanel(tasks) {
-  const res = spawnSync(process.execPath, [SCRIPT, 'subagent'], {
-    input: JSON.stringify({ tasks }),
-    encoding: 'utf8',
-    timeout: 5000
-  });
+  const res = spawnSubagent(JSON.stringify({ tasks }));
   if (res.error) throw res.error;
   if (res.status !== 0) {
     throw new Error(`statusline.js subagent exited with ${res.status}\n${res.stderr || ''}`);

--- a/statusline.js
+++ b/statusline.js
@@ -441,6 +441,14 @@ function readCachedUsage() {
   }
 }
 
+// Serialize usage data into the on-disk cache shape ({ timestamp, data }). Pure -- no fs --
+// so setCachedUsage and the test/preview cache seeds all produce exactly the same bytes the
+// real writer would; a reader/writer format mismatch becomes structurally impossible instead
+// of merely untested. `timestamp` defaults to now; tests override it to seed a stale cache.
+function serializeUsageCache(data, timestamp = Date.now()) {
+  return JSON.stringify({ timestamp, data });
+}
+
 // Write usage data to cache (shared across all sessions)
 function setCachedUsage(data) {
   try {
@@ -448,12 +456,7 @@ function setCachedUsage(data) {
       fs.mkdirSync(CACHE_DIR, { recursive: true });
     }
 
-    const cache = {
-      timestamp: Date.now(),
-      data: data
-    };
-
-    fs.writeFileSync(USAGE_CACHE_FILE, JSON.stringify(cache), 'utf8');
+    fs.writeFileSync(USAGE_CACHE_FILE, serializeUsageCache(data), 'utf8');
   } catch (e) {
     // Silently fail
   }
@@ -818,5 +821,5 @@ if (require.main === module) {
     readStdinThen(timeoutMs, (input) => finish(parseInput(input)));
   }
 } else {
-  module.exports = { parseScopedLimits, parseUsagePayload, normalizePercentage, readStdinThen, renderStatusLine, renderSubagentTask };
+  module.exports = { parseScopedLimits, parseUsagePayload, serializeUsageCache, normalizePercentage, readStdinThen, renderStatusLine, renderSubagentTask };
 }

--- a/test/docs-drift.test.js
+++ b/test/docs-drift.test.js
@@ -1,0 +1,93 @@
+// docs/index.html hand-authors two mocked statusline rows (hero example, subagent panel)
+// as static markup so the marketing site doesn't need to run statusline.js. Nothing keeps
+// those numbers/labels in sync with what the code actually renders -- #32 already found one
+// such drift (a wrong reset countdown). This reconstructs each mock's visible text and
+// byte-compares it against a real renderStatusLine()/renderSubagentTask() call for the same
+// scenario, so a future drift fails CI instead of sitting unnoticed.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { renderStatusLine, renderSubagentTask } = require('../statusline.js');
+
+const HTML = fs.readFileSync(path.join(__dirname, '..', 'docs', 'index.html'), 'utf8');
+const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+// Pull the markup for the <div class="line...">...</div> that contains `marker` -- searches
+// backward from the marker to the enclosing line div's opening tag (none of these rows nest
+// a <div>, so the first </div> after that is always the row's own close).
+function extractLine(marker) {
+  const idx = HTML.indexOf(marker);
+  assert.ok(idx !== -1, `marker not found in docs/index.html: ${marker}`);
+  const lineStart = HTML.lastIndexOf('<div class="line', idx);
+  const lineEnd = HTML.indexOf('</div>', lineStart);
+  return HTML.slice(lineStart, lineEnd);
+}
+
+// Reconstruct the plain text a reader sees. Two elements carry no text content at all --
+// the context bar (pure <i> boxes) and the "│" separators' surrounding gap (CSS padding/
+// margin, not a text node in the tightly-packed subagent rows) -- so both are special-cased
+// to match how renderContextBar()/SEGMENT_SEP actually format them, rather than relying on
+// incidental whitespace in the source markup.
+function htmlLineToText(html) {
+  return html
+    .replace(/<span class="bar">([\s\S]*?)<\/span>/g, (_, inner) => {
+      const total = (inner.match(/<i/g) || []).length;
+      const on = (inner.match(/<i class="on">/g) || []).length;
+      return ' ' + '█'.repeat(on) + '░'.repeat(total - on);
+    })
+    .replace(/<span class="sep">│<\/span>/g, ' │ ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+test('hero mock line matches a real renderStatusLine() output', () => {
+  const mockText = htmlLineToText(extractLine('class="proj">my-project'));
+
+  const data = {
+    model: { display_name: 'Opus 4.8 (1M context)' },
+    effort: { level: 'high' },
+    context_window: { remaining_percentage: 55 }, // used 45 -> "C45"
+    cost: { total_cost_usd: 44.21 }
+  };
+  const facts = { dirname: 'my-project', branch: 'main', sync: '↑2↓1', task: '', cols: undefined };
+  const usage = { current: 'H14 ↺ 4h20m', weekly: 'W31 ↺ 2d13h' };
+  const realText = stripAnsi(renderStatusLine(data, facts, usage));
+
+  assert.strictEqual(mockText, realText, 'docs/index.html hero mock has drifted from a real render');
+});
+
+test('subagent mock rows match a real renderSubagentTask() output', () => {
+  const scenarios = [
+    {
+      marker: '<span>architecture-review</span>',
+      task: { id: 't', name: 'architecture-review', model: 'claude-opus-5', effort: 'max', tokenCount: 51000, contextWindowSize: 100000, startTime: Math.floor(Date.now() / 1000) - 252 }
+    },
+    {
+      marker: '<span>test-coverage</span>',
+      task: { id: 't', name: 'test-coverage', model: 'claude-sonnet-5', effort: 'high', tokenCount: 36000, contextWindowSize: 100000, startTime: Math.floor(Date.now() / 1000) - 108 }
+    }
+  ];
+
+  for (const { marker, task } of scenarios) {
+    // The "○ " bullet is docs/index.html's own chrome (a running-task marker), not
+    // something renderSubagentTask ever emits -- strip it before comparing.
+    const mockText = htmlLineToText(extractLine(marker)).replace(/^○\s*/, '');
+    const realText = stripAnsi(renderSubagentTask(task));
+
+    // Elapsed time is flavor text, not a fact derivable from anything else in the mock --
+    // compare every segment exactly except accept any well-formed elapsed value.
+    const mockParts = mockText.split(' │ ');
+    const realParts = realText.split(' │ ');
+    assert.strictEqual(mockParts.length, realParts.length, `${task.name}: segment count drifted`);
+    for (let i = 0; i < mockParts.length - 1; i++) {
+      assert.strictEqual(mockParts[i], realParts[i], `${task.name}: segment ${i} has drifted`);
+    }
+    // Matches formatElapsed()'s three branches: "<h>h<m>m", "<m>m<s>s", "<s>s".
+    const elapsed = mockParts[mockParts.length - 1];
+    assert.match(elapsed, /^⏱ (\d+h\d+m|\d+m\d{1,2}s|\d{1,2}s)$/, `${task.name}: elapsed segment "${elapsed}" isn't a well-formed duration`);
+  }
+});

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -1,0 +1,90 @@
+// Shared test/preview fixture: fake HOME construction, usage-cache seeding, diverged git
+// repos, and spawn wrappers for both statusline.js entry points. Required by both
+// test/render.test.js and scripts/preview.js so the on-disk shapes they seed can never
+// silently drift from what the real writer produces. Dev-only -- outside the package.json
+// `files` whitelist, never ships.
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { serializeUsageCache } = require('../statusline.js');
+
+const SCRIPT = path.join(__dirname, '..', 'statusline.js');
+
+// Fresh throwaway HOME with .claude/cache pre-created. Caller owns cleanup.
+function makeHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-home-'));
+  fs.mkdirSync(path.join(home, '.claude', 'cache'), { recursive: true });
+  return home;
+}
+
+// Tokenless credentials file -- getApiUsage bails before any network/keychain call.
+function seedCredentials(home) {
+  fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), '{}');
+}
+
+// Seed usage-cache.json through the real writer's serialization, so a reader/writer format
+// mismatch can't happen. `timestamp` defaults to now; pass an offset to exercise the
+// stale/expired-cache fallback paths.
+function seedUsageCache(home, data, timestamp = Date.now()) {
+  fs.writeFileSync(
+    path.join(home, '.claude', 'cache', 'usage-cache.json'),
+    serializeUsageCache(data, timestamp)
+  );
+}
+
+// Fake .git/HEAD pointing at `branch` -- enough for the branch segment, no real git needed.
+function seedFakeRepo(dir, branch) {
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
+}
+
+function git(dir, args) { return spawnSync('git', args, { cwd: dir, encoding: 'utf8' }); }
+function hasGit() { return spawnSync('git', ['--version'], { encoding: 'utf8' }).status === 0; }
+function gitCommit(dir, tag) {
+  fs.writeFileSync(path.join(dir, 'f-' + tag), tag);
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', tag]);
+}
+
+// Build a real git repo (already created at `dir`) diverged `ahead`/`behind` commits from a
+// tracked upstream (origin/<branch>), so `git rev-list @{u}...HEAD` reports real counts.
+// `branch`, if given, forces the displayed branch name; otherwise git's default is kept.
+// Returns the resolved branch name. Throws if git is unavailable -- callers that need a
+// graceful fallback (no git installed) wrap the call in their own try/catch.
+function seedDivergedRepo(dir, { ahead = 0, behind = 0, branch } = {}) {
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 't@t']);
+  git(dir, ['config', 'user.name', 'test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  git(dir, ['config', 'remote.origin.url', '.']);
+  git(dir, ['config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*']);
+  gitCommit(dir, 'base');
+  if (branch) git(dir, ['branch', '-M', branch]);
+  const resolvedBranch = branch || git(dir, ['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+  const baseSha = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
+  for (let i = 0; i < behind; i++) gitCommit(dir, 'up' + i);
+  const upstreamSha = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
+  git(dir, ['update-ref', 'refs/remotes/origin/' + resolvedBranch, upstreamSha]);
+  git(dir, ['config', 'branch.' + resolvedBranch + '.remote', 'origin']);
+  git(dir, ['config', 'branch.' + resolvedBranch + '.merge', 'refs/heads/' + resolvedBranch]);
+  git(dir, ['reset', '--hard', '-q', baseSha]);
+  for (let i = 0; i < ahead; i++) gitCommit(dir, 'local' + i);
+  return resolvedBranch;
+}
+
+// Spawn statusline.js's main entry point with the given stdin string and env.
+function spawnMain(input, env) {
+  return spawnSync(process.execPath, [SCRIPT], { input, encoding: 'utf8', timeout: 5000, env });
+}
+
+// Spawn statusline.js's subagent entry point (`node statusline.js subagent`).
+function spawnSubagent(input, env) {
+  return spawnSync(process.execPath, [SCRIPT, 'subagent'], { input, encoding: 'utf8', timeout: 5000, env: env || process.env });
+}
+
+module.exports = {
+  SCRIPT, makeHome, seedCredentials, seedUsageCache, seedFakeRepo,
+  git, hasGit, gitCommit, seedDivergedRepo, spawnMain, spawnSubagent
+};

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -40,7 +40,15 @@ function seedFakeRepo(dir, branch) {
   fs.writeFileSync(path.join(dir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
 }
 
-function git(dir, args) { return spawnSync('git', args, { cwd: dir, encoding: 'utf8' }); }
+// Throws on failure -- a swallowed error here would let seedDivergedRepo return a resolved
+// branch/counts that don't reflect what git actually did.
+function git(dir, args) {
+  const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+  if (res.error || res.status !== 0) {
+    throw res.error || new Error(`git ${args.join(' ')} failed (exit ${res.status}): ${res.stderr || ''}`);
+  }
+  return res;
+}
 function hasGit() { return spawnSync('git', ['--version'], { encoding: 'utf8' }).status === 0; }
 function gitCommit(dir, tag) {
   fs.writeFileSync(path.join(dir, 'f-' + tag), tag);

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -7,16 +7,17 @@
 
 const { test, after } = require('node:test');
 const assert = require('node:assert');
-const { spawnSync } = require('node:child_process');
 const { EventEmitter } = require('node:events');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-
-const SCRIPT = path.join(__dirname, '..', 'statusline.js');
+const {
+  makeHome, seedCredentials, seedUsageCache, seedFakeRepo,
+  git, hasGit, gitCommit, seedDivergedRepo: buildDivergedRepo, spawnMain, spawnSubagent
+} = require('./fixture.js');
 
 // Empty fake HOME so the todos/credentials lookups find nothing -> deterministic.
-const FAKE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-test-'));
+const FAKE_HOME = makeHome();
 after(() => fs.rmSync(FAKE_HOME, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
 
 // Run statusline.js with the given stdin string. Returns { code, raw, clean }.
@@ -44,7 +45,7 @@ function run(input, opts = {}) {
   } else {
     delete env.CTXLINE_DISABLE;
   }
-  const res = spawnSync(process.execPath, [SCRIPT], { input, encoding: 'utf8', timeout: 5000, env });
+  const res = spawnMain(input, env);
   const raw = res.stdout || '';
   const clean = raw.replace(/\x1b\[[0-9;]*m/g, ''); // strip ANSI for readable assertions
   return { code: res.status, raw, clean };
@@ -54,20 +55,14 @@ function run(input, opts = {}) {
 // bails out before any network/keychain call) and optionally a seeded usage cache
 // of a given age. Lets us exercise the cache-first / stale-fallback logic offline.
 function seedHome({ cacheAgeMs, percentage = 42, weeklyPercentage = 31 } = {}) {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-cache-'));
-  const claudeDir = path.join(home, '.claude');
-  fs.mkdirSync(path.join(claudeDir, 'cache'), { recursive: true });
-  fs.writeFileSync(path.join(claudeDir, '.credentials.json'), '{}'); // no accessToken -> API skipped
+  const home = makeHome();
+  seedCredentials(home); // no accessToken -> API skipped
   if (cacheAgeMs != null) {
-    const cache = {
-      timestamp: Date.now() - cacheAgeMs,
-      data: {
-        fiveHour: { percentage, resetsAt: new Date(Date.now() + 2 * 3600 * 1000).toISOString() },
-        // 62h out -> exercises the day-aware countdown (2d14h)
-        weekly: { percentage: weeklyPercentage, resetsAt: new Date(Date.now() + 62 * 3600 * 1000).toISOString() }
-      }
-    };
-    fs.writeFileSync(path.join(claudeDir, 'cache', 'usage-cache.json'), JSON.stringify(cache));
+    seedUsageCache(home, {
+      fiveHour: { percentage, resetsAt: new Date(Date.now() + 2 * 3600 * 1000).toISOString() },
+      // 62h out -> exercises the day-aware countdown (2d14h)
+      weekly: { percentage: weeklyPercentage, resetsAt: new Date(Date.now() + 62 * 3600 * 1000).toISOString() }
+    }, Date.now() - cacheAgeMs);
   }
   return home;
 }
@@ -110,28 +105,15 @@ function seedScopedCache(home, models) {
     ...m,
     resetsAt: new Date(Date.now() + 62 * 3600 * 1000).toISOString()
   }));
-  fs.writeFileSync(cacheFile, JSON.stringify(cache));
+  seedUsageCache(home, cache.data, cache.timestamp);
 }
 
 // Make a real dir with a seeded .git/HEAD so the branch segment renders deterministically.
 function seedRepo(branch = 'feature/x') {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-repo-'));
-  fs.mkdirSync(path.join(dir, '.git'));
-  fs.writeFileSync(path.join(dir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`);
+  seedFakeRepo(dir, branch);
   after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
   return dir;
-}
-
-// --- real-git helpers for the ahead/behind segment ---
-function git(dir, args) { return spawnSync('git', args, { cwd: dir, encoding: 'utf8' }); }
-function hasGit() {
-  const r = spawnSync('git', ['--version'], { encoding: 'utf8' });
-  return r.status === 0;
-}
-function gitCommit(dir, tag) {
-  fs.writeFileSync(path.join(dir, 'f-' + tag), tag);
-  git(dir, ['add', '-A']);
-  git(dir, ['commit', '-q', '-m', tag]);
 }
 
 // Real git repo whose HEAD is `ahead` commits ahead and `behind` behind a tracked
@@ -139,31 +121,13 @@ function gitCommit(dir, tag) {
 function seedDivergedRepo({ ahead = 0, behind = 0 } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-gitdiv-'));
   after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
-  git(dir, ['init', '-q']);
-  git(dir, ['config', 'user.email', 't@t']);
-  git(dir, ['config', 'user.name', 'test']);
-  git(dir, ['config', 'commit.gpgsign', 'false']);
-  // register origin so the merge ref maps to a remote-tracking branch (@{u} resolves)
-  git(dir, ['config', 'remote.origin.url', '.']);
-  git(dir, ['config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*']);
-  gitCommit(dir, 'base');
-  const branch = git(dir, ['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
-  const baseSha = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
-  // build the upstream (behind) chain on top of base, park it in origin/<branch>
-  for (let i = 0; i < behind; i++) gitCommit(dir, 'up' + i);
-  const upstreamSha = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
-  git(dir, ['update-ref', 'refs/remotes/origin/' + branch, upstreamSha]);
-  git(dir, ['config', 'branch.' + branch + '.remote', 'origin']);
-  git(dir, ['config', 'branch.' + branch + '.merge', 'refs/heads/' + branch]);
-  // reset HEAD back to base, then build the local (ahead) chain -> diverges from upstream
-  git(dir, ['reset', '--hard', '-q', baseSha]);
-  for (let i = 0; i < ahead; i++) gitCommit(dir, 'local' + i);
+  buildDivergedRepo(dir, { ahead, behind });
   return dir;
 }
 
 // Throwaway HOME so each git test gets an isolated git-cache.json.
 function freshHome() {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-githome-'));
+  const home = makeHome();
   after(() => fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
   return home;
 }
@@ -840,7 +804,7 @@ test('disable accepts multiple segments', () => {
 function runSubagent(input, opts = {}) {
   const home = opts.home || FAKE_HOME;
   const env = { ...process.env, HOME: home, USERPROFILE: home };
-  const res = spawnSync(process.execPath, [SCRIPT, 'subagent'], { input, encoding: 'utf8', timeout: 5000, env });
+  const res = spawnSubagent(input, env);
   const raw = res.stdout || '';
   const lines = raw.trim() ? raw.trim().split('\n').map(l => JSON.parse(l)) : [];
   return { code: res.status, raw, lines };


### PR DESCRIPTION
- Export `serializeUsageCache` so the writer and every test/preview cache seed share one format
- `test/fixture.js`: shared HOME/cache/repo/spawn setup for `render.test.js` + `scripts/preview.js`
- `npm run preview:svg` generates `docs/assets/preview.svg`'s statusline tspans from a real render (fixed a stale countdown along the way)
- `test/docs-drift.test.js`: fails CI if `docs/index.html`'s mocked rows drift from a real render

`npm test` 88/88, `npm run preview` unchanged.

Fixes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for keeping statusline documentation previews synchronized.
  - Documented the preview SVG regeneration and verification workflow.

- **New Features**
  - Added a command to regenerate statusline preview SVG content from live renders.
  - Added checks that detect discrepancies between documented examples and actual statusline output.

- **Tests**
  - Introduced shared fixtures for consistent rendering and preview validation.
  - Added coverage for main and subagent statusline examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->