### PR TITLE
docs: trim CLAUDE.md and record the usage-cooldown atomicity decision

### DIFF
--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: restyle-statusline
-description: Change the statusline's visible design — layout, segment format, labels, colors, bars, or countdowns. Use when the user wants to redesign, compact, expand, recolor, or relabel the rendered line. Captures every file that mirrors the format so a restyle needs no re-discovery.
+description: Change the statusline's visible design — layout, segment format, labels, colors, bars, countdowns — or its cache shape / stdin fields. Use when the user wants to redesign, compact, expand, recolor, or relabel the rendered line, or when a `statusline.js` change has to be mirrored in the tests, preview, SVG, or site. Captures every edit point and the test-harness options so a sync pass needs no re-discovery.
 ---
 
 # Restyle statusline
@@ -73,6 +73,15 @@ Ahead/behind: both the site (`.ahead` green / `.behind` `#f85149`) and `statusli
 - Don't touch installers (`bin/install.js`, `install.sh`, `install.ps1`) — frozen. No Full/Lite prompt or second file (deleted upstream).
 - README has no sample line — leave it.
 - New ANSI color in `colors` (top of `statusline.js`) → add it to `scripts/preview-svg.js`'s `ANSI_HEX` table too, or `npm run preview:svg` silently falls back to the default text color for it.
+
+## Test harness options
+
+`test/fixture.js` backs both `test/render.test.js` and `scripts/preview.js`: fake-HOME construction, `usage-cache.json` seeding (through `statusline.js`'s exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside `package.json`'s `files` whitelist.
+
+- `run()` opts: `columns` (unset → single line), `disable` (→ `CTXLINE_DISABLE`).
+- Preview's `render()` takes the matching params — narrow scenario passes 40, opt-out scenario passes `usage,cost` — plus `models` (`[{ label, percentage, resetsInMin }]`) for the scoped-limit scenario.
+- Both clear `COLUMNS`/`CTXLINE_DISABLE` when unset, so a dev-env value can't skew output.
+- Git ahead/behind tests need real `git` (skipped if absent) and a fresh HOME per test, to isolate `git-cache.json`.
 
 ## Render to verify (ANSI in terminal)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 **Render seam.** `collectFacts(data)` gathers everything touching fs/child_process/env (git branch + ahead/behind, in-progress task, `COLUMNS`); pure `renderStatusLine(data, facts, usage)` formats; `outputStatus` is a ~3-line writer, try/catch → `Status unavailable`. `outputFallback` calls the same renderer with a static git/task-free `facts` (`cols: undefined` → single line, matching the fallback contract). Entry guarded by `require.main === module` so `test/render.test.js` can `require()` and call exports directly instead of spawning: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`.
 
 **Caches** (both in `~/.claude/cache/`):
-- `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10min. `lastAttempt` — stamped by `recordUsageAttempt()` before the request fires, success or failure — is the retry cooldown, independent of `timestamp`. Bars re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
+- `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10m. `lastAttempt` — stamped by `recordUsageAttempt()` before the request fires, success or failure — is the retry cooldown, independent of `timestamp`. Bars re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
 - `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
 
 **Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg → several scoped bars read as one group while a nearly-spent one still stands out.
@@ -102,7 +102,7 @@ Skips everything main mode does besides stdin parsing — no usage API, git, tod
 
 `statusline.js` is source of truth; five files mirror the visible line and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
 
-`test/fixture.js` — shared by test + preview: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
+Shared harness, not one of the five — `test/fixture.js`, used by test + preview: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
 
 - `scripts/preview.js` — spawns the real `statusline.js` via the fixture against a seeded cache + stdin JSON. Cache-shape change → update the seed data passed to `seedUsageCache` **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add to the input object. The release body shows `head -n 1` of its output → keep the primary-line `console.log` **first**.
 - `test/render.test.js` — same fixture, same breakage; assertions pin visible labels/percentages/colors/order. `colors` codes change → update the constants atop the file.
@@ -112,7 +112,7 @@ Skips everything main mode does besides stdin parsing — no usage API, git, tod
 
 Full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.
 
-Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar; `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
+Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar glyph (`buildUsageBar` builds text-only `H`/`W`/scoped segments despite the name); `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
 
 Rule of thumb: change to **what the line looks like** → test assertions. Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 
 **Deliberate non-goals — do not re-propose:**
 - **Merging the two caches, or the two duration formatters** (`buildUsageBar`'s countdown vs `formatElapsed`). Two callers each, differing validators / units / refresh policies (git 5s/60s vs usage 30s/10m; countdown vs elapsed) — a shared `withCache`/`formatDuration` moves complexity into parameters. Revisit only on a third caller.
-- **Making the `lastAttempt` cooldown atomic.** The check (`getLastAttemptAge()`) and the claim (`recordUsageAttempt()`) aren't atomic across processes — concurrent hook invocations can both call `getApiUsage()`. Worst case is one extra API call, never a crash or bad render; a filesystem lock plus a multi-process test contradicts the single-file, zero-dependency constraint. Revisit only if concurrent hook processes prove common.
+- **Making the `lastAttempt` cooldown atomic.** The check (`getLastAttemptAge()`) and the claim (`recordUsageAttempt()`) aren't atomic across processes — every render that reads a stale `lastAttempt` before any of them writes one calls `getApiUsage()`, so the extra calls scale with how many hook processes render at once (the cache is shared across sessions), not a fixed one. Still never a crash or bad render; a filesystem lock plus a multi-process test contradicts the single-file, zero-dependency constraint. Revisit only if concurrent hook processes prove common.
 
 ## Subagent mode (`subagentStatusLine`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,21 +19,20 @@ npm test           # render tests (Node built-in runner, zero deps)
 npm run preview    # sample lines for every color band + fallback
 npm run preview:svg # regenerate docs/assets/preview.svg's statusline tspans from a real render
 npm pack --dry-run # preview what publishes
-# Don't publish by hand — see Releasing.
+# Never publish by hand — see Distribution + releasing.
 
-# Ad-hoc render — feed the stdin JSON Claude Code sends:
+# Main line — the stdin JSON Claude Code sends:
 echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp/x"},"session_id":"t","context_window":{"remaining_percentage":40}}' | node statusline.js
 
-# Ad-hoc subagent-row render (subagentStatusLine mode — see below):
+# Subagent rows (startTime = 4m12s ago, epoch seconds — format note below):
 echo '{"tasks":[{"id":"t1","name":"reviewer","model":"claude-opus-5","effort":"max","tokenCount":45200,"contextWindowSize":200000,"startTime":'$(($(date +%s)-252))'}]}' | node statusline.js subagent
-# startTime = 4m12s ago in epoch seconds (format note below).
 ```
 
 Publishing + local-install detail: `docs/DEV.md`.
 
 ## Architecture
 
-`statusline.js` is the entire product — standalone, zero-dependency Node (built-ins only). Installers copy it to `~/.claude/hooks/`. No non-builtin `require()`s, no module split, no assuming sibling files exist at runtime.
+`statusline.js` is the entire product — standalone, zero-dependency Node (built-ins only). Installers copy it to `~/.claude/hooks/`: no non-builtin `require()`s, no module split, no assuming sibling files exist at runtime.
 
 **Execution contract.** Claude Code pipes session JSON via stdin every render, reads stdout (one or two lines). Must **always** print, **never** hang/throw — every path falls back to cached/partial/`outputFallback()`, failures swallow silently.
 
@@ -43,49 +42,47 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 
 **Segment opt-out.** `CTXLINE_DISABLE` comma list parsed once into `DISABLED` (trimmed, lowercased). Recognized: `branch`, `effort`, `cost`, `task`, `usage` (H+W). `dir`/`model`/`context` always render; unknown names ignored. Disabling skips the work, not just the output — `usage` means no network/cache/credentials at all.
 
-**Responsive layout (`layout()`).** Visible width (ANSI stripped) > `COLUMNS - WIDTH_MARGIN` → two lines: line 1 dir/branch + model/effort + `C`; line 2 `H`/`W` + `$` + task. Wraps only when `COLUMNS` is a known positive int and line 2 is non-empty — unknown width, wide terminals, nothing to wrap all stay single-line. `outputFallback()` stays single-line. `cols` is a parameter, never an env read, so `layout()`/`renderStatusLine()` have no side effects.
+**Responsive layout (`layout()`).** Visible width (ANSI stripped) > `COLUMNS - WIDTH_MARGIN` → two lines: line 1 dir/branch + model/effort + `C`; line 2 `H`/`W` + `$` + task. Fires only when `COLUMNS` is a known positive int and line 2 is non-empty — unknown width, wide terminal, or nothing to wrap stays single-line, as does `outputFallback()`. `cols` is a parameter, never an env read, so `layout()`/`renderStatusLine()` have no side effects.
 
 **Segment sources + gotchas** (each best-effort):
 
 | segment | source | gotchas |
 |---|---|---|
-| dir + branch | basename of `current_dir`; branch read straight from `.git/HEAD`, no subprocess | `resolveGitDir()` walks up; handles worktree (`.git` file) + detached HEAD (short sha); tail-truncated to `MAX_BRANCH_LEN` 24 (keeps leading ticket ID); `''` on failure |
-| `↑N↓M` | `getGitAheadBehind(dir)` — the only `git` subprocess: `execFileSync('git', ['rev-list','--left-right','--count','@{u}...HEAD'])` | no shell (faster cold spawn, `@{u}` passed literally); output `"<behind>\t<ahead>"`; `GIT_TIMEOUT_MS` 500ms; cache-fronted; `null` → omitted; omit a zero side; absent when in sync / no upstream / detached |
+| dir + branch | basename of `current_dir`; branch straight from `.git/HEAD`, no subprocess | `resolveGitDir()` walks up; handles worktree (`.git` file) + detached HEAD (short sha); tail-truncated to `MAX_BRANCH_LEN` 24 (keeps leading ticket ID); `''` on failure |
+| `↑N↓M` | `getGitAheadBehind(dir)` — the only `git` subprocess (`execFileSync`, `rev-list --left-right --count @{u}...HEAD`) | no shell (faster cold spawn, `@{u}` passed literally); output is `"<behind>\t<ahead>"`; `GIT_TIMEOUT_MS` 500ms; cache-fronted; omitted on `null`, in sync, no upstream, detached; a zero side is dropped |
 | model · effort | stdin | `(1M context)` → `(1M)`; effort ranks low<medium<high<xhigh<max<ultracode, only `max` (red) + `ultracode` (purple) highlighted, rest dim |
 | `C` | stdin `remaining_percentage` | always available |
-| `$` | stdin `cost.total_cost_usd`, no network/cache | `Number.isFinite`-guarded; client-side estimate at API pricing — for subscription users not actual billing |
+| `$` | stdin `cost.total_cost_usd`, no network/cache | `Number.isFinite`-guarded; client-side estimate at API pricing — for subscription users, not actual billing |
 | `H` / `W` | stdin `rate_limits` via `buildUsageFromStdin()`, else `getRawUsage()` → OAuth API | `rate_limits` exists only for Claude.ai Pro/Max **after the first API response** — absent at cold start and for API-key users, hence the fallback |
 | scoped weekly | OAuth API only | never arrives via stdin; `getScopedColor` (orange, red ≥90), not the H/W thresholds |
 | task | newest `~/.claude/todos/<sessionId>*-agent-*.json` | `activeForm` of the `in_progress` todo |
 
 **Usage API.** `GET api.anthropic.com/api/oauth/usage`, bearer token + `anthropic-beta: oauth-2025-04-20`. Token from `getCredentials()`: `~/.claude/.credentials.json`, then macOS keychain. API-key users get no usage.
-- Both adapters return `{ fiveHour, weekly, models }` and feed `buildUsageBars(raw)` — one positional object. `buildUsageFromStdin()`'s `models` is always `[]` (stdin never carries scoped limits).
+- Both adapters return `{ fiveHour, weekly, models }` → `buildUsageBars(raw)`, one positional object. `buildUsageFromStdin()`'s `models` is always `[]` (stdin never carries scoped limits).
 - `parseUsagePayload(body)` — pure, no fs/network; `null` on unparseable JSON or a missing/non-finite `five_hour` utilization. `getApiUsage()` calls it and owns only credentials/socket/timeout/cache-write.
 - `getRawUsage()` is cache-first, and checks the `lastAttempt` cooldown (`getLastAttemptAge()`, `FRESH_TTL_MS`) before calling `getApiUsage()` at all → a failed/timed-out refresh backs off the same as a successful one.
 - `parseScopedLimits(usage)` reads `limits[]` for `kind: 'weekly_scoped'`; label = first initial of `scope.model.display_name` (new model family needs no code change). Legacy flat `seven_day_opus`/`seven_day_sonnet` only when `limits` yields nothing → neither shape double-counts.
-- Scoped limits never arrive via stdin → `resolveUsage()` calls `getRawUsage()` for those bars even when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; slow/failed call costs only the scoped bars.
+- `resolveUsage()` still calls `getRawUsage()` for the scoped bars when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; a slow/failed call costs only those bars.
 
 **Render seam.** `collectFacts(data)` gathers everything touching fs/child_process/env (git branch + ahead/behind, in-progress task, `COLUMNS`); pure `renderStatusLine(data, facts, usage)` formats; `outputStatus` is a ~3-line writer, try/catch → `Status unavailable`. `outputFallback` calls the same renderer with a static git/task-free `facts` (`cols: undefined` → single line, matching the fallback contract). Entry guarded by `require.main === module` so `test/render.test.js` can `require()` and call exports directly instead of spawning: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`.
 
 **Caches** (both in `~/.claude/cache/`):
-- `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10m. `lastAttempt` — stamped by `recordUsageAttempt()` before the request fires, success or failure — is the retry cooldown, independent of `timestamp`. Bars re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
+- `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10m. `lastAttempt` — stamped by `recordUsageAttempt()` before the request fires, success or failure — is the retry cooldown, independent of `timestamp`. Segments re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
 - `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
 
 **Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg → several scoped bars read as one group while a nearly-spent one still stands out.
 
-**Deliberately duplicated, do not merge:** the two caches, and the two duration formatters (`buildUsageBar`'s countdown vs `formatElapsed`). Two callers each, differing validators / units / refresh policies (git 5s/60s vs usage 30s/10m; countdown vs elapsed) — a shared `withCache`/`formatDuration` moves complexity into parameters. Revisit only on a third caller.
-
-**Not actioned, deliberately:** the `lastAttempt` cooldown check (`getLastAttemptAge()`) and claim (`recordUsageAttempt()`) aren't atomic across processes — concurrent hook invocations can both call `getApiUsage()`. Worst case is one extra API call, never a crash or bad render; a filesystem lock plus a multi-process test contradicts the single-file, zero-dependency constraint. Revisit only if concurrent hook processes prove common.
+**Deliberate non-goals — do not re-propose:**
+- **Merging the two caches, or the two duration formatters** (`buildUsageBar`'s countdown vs `formatElapsed`). Two callers each, differing validators / units / refresh policies (git 5s/60s vs usage 30s/10m; countdown vs elapsed) — a shared `withCache`/`formatDuration` moves complexity into parameters. Revisit only on a third caller.
+- **Making the `lastAttempt` cooldown atomic.** The check (`getLastAttemptAge()`) and the claim (`recordUsageAttempt()`) aren't atomic across processes — concurrent hook invocations can both call `getApiUsage()`. Worst case is one extra API call, never a crash or bad render; a filesystem lock plus a multi-process test contradicts the single-file, zero-dependency constraint. Revisit only if concurrent hook processes prove common.
 
 ## Subagent mode (`subagentStatusLine`)
 
-Second entry point in the same file, activated by `process.argv[2] === 'subagent'` — wired in `settings.json` as a separate command from `statusLine`:
+Second entry point in the same file, activated by `process.argv[2] === 'subagent'` — one row per running subagent task in the agent panel, wired in `settings.json` as a separate command from `statusLine`:
 
 ```json
 { "subagentStatusLine": { "type": "command", "command": "node ~/.claude/hooks/statusline.js subagent" } }
 ```
-
-One row per running subagent task in the agent panel.
 
 - Stdin: `{ tasks: [...], ... }` (base fields `session_id`/`cwd`/`columns` present but unused). Each task: `id`, `name`/`description`/`label`, `type`, `status`, `startTime`, `model` (resolved ID, absent until resolved), `effort` (level string or numeric token budget, absent when the subagent inherits session effort), `contextWindowSize`, `tokenCount`, `tokenSamples`, `cwd`.
 - Stdout: one `{"id","content"}` JSON line per task to override. Omitted id → default rendering; empty `content` → row hidden.
@@ -100,32 +97,32 @@ Skips everything main mode does besides stdin parsing — no usage API, git, tod
 
 ## Keep in sync when `statusline.js` changes
 
-`statusline.js` is source of truth; five files mirror the visible line and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
+`statusline.js` is source of truth; the five files below mirror the visible line and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
 
-Shared harness, not one of the five — `test/fixture.js`, used by test + preview: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
+| file | mirrors | trap |
+|---|---|---|
+| `scripts/preview.js` | cache seed passed to `seedUsageCache`, `render()` params/labels, stdin input object | release body shows `head -n 1` → keep the primary-line `console.log` **first**; a stale seed makes usage render wrong or vanish |
+| `test/render.test.js` | visible labels / percentages / colors / order | ANSI `colors` constants sit atop the file — update them when codes change |
+| `docs/assets/preview.svg` | the statusline `<text>` elements' `<tspan>` runs (README + site) | generated, never hand-edited — run `npm run preview:svg` after anything that shifts this scenario's output; window chrome, prompt lines, and the "○ " bullet stay hand-authored |
+| `docs/index.html` | hero mock (`.term .line`) + subagent-panel rows | byte-compared against real `renderStatusLine()`/`renderSubagentTask()` calls by `test/docs-drift.test.js`, so drift fails `npm test`; inspector `SIGNALS[]` and `.term` color classes are unchecked — hand-verify |
+| `CLAUDE.md` | format diagram (top), segment-source table, visible contract below | — |
 
-- `scripts/preview.js` — spawns the real `statusline.js` via the fixture against a seeded cache + stdin JSON. Cache-shape change → update the seed data passed to `seedUsageCache` **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add to the input object. The release body shows `head -n 1` of its output → keep the primary-line `console.log` **first**.
-- `test/render.test.js` — same fixture, same breakage; assertions pin visible labels/percentages/colors/order. `colors` codes change → update the constants atop the file.
-- `docs/assets/preview.svg` — the statusline `<text>` elements' `<tspan>` runs; shown in README + site. Generated, not hand-edited: `npm run preview:svg` (`scripts/preview-svg.js`) renders the real ANSI output for the same fixed scenario and rewrites just those tspans (ANSI SGR → hex, via its own `ANSI_HEX` table); window chrome, prompt lines, and the "○ " running-task bullet stay hand-authored. Run it after any change that would shift this scenario's output (colors, thresholds, format).
-- `docs/index.html` — hero mock (`.term .line`) and the subagent-panel rows are byte-compared against a real `renderStatusLine()`/`renderSubagentTask()` call by `test/docs-drift.test.js`, so site drift fails `npm test`. Inspector `SIGNALS[]` and `.term` color classes are still unchecked — hand-verify those.
-- `CLAUDE.md` — format diagram (top), segment-source table, visible contract below.
+`test/fixture.js` is the shared harness behind test + preview, not one of the five: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
 
-Full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.
+Triggers: change to **what the line looks like** → test assertions (+ `npm run preview:svg`). Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
+
+Full edit-point map, test-harness options, and the ANSI/SVG color tables: `.claude/skills/restyle-statusline/SKILL.md`.
 
 Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar glyph (`buildUsageBar` builds text-only `H`/`W`/scoped segments despite the name); `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
-
-Rule of thumb: change to **what the line looks like** → test assertions. Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
-
-Test harness: `run()` opts `columns` (unset → single line) and `disable` (→ `CTXLINE_DISABLE`); preview's `render()` takes matching params (narrow scenario 40, opt-out scenario `usage,cost`) plus `models` (`[{ label, percentage, resetsInMin }]`) for the scoped-limit scenario. Both clear `COLUMNS`/`CTXLINE_DISABLE` when unset so a dev-env value can't skew output. Git ahead/behind tests need real `git` (skipped if absent) and a fresh HOME per test (isolated `git-cache.json`).
 
 ## Do not touch the installers
 
 Work in `statusline.js` only. Install path is frozen (inherited working from upstream):
-- Don't change behavior of `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name) or wiring a settings.json entry a shipped `statusline.js` feature already depends on (e.g. `subagentStatusLine`).
+- No behavior change to `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name) or wiring a settings.json entry a shipped `statusline.js` feature already depends on (e.g. `subagentStatusLine`).
 - `npx ctxline-claude` → `bin/install.js` installs silently, no prompts. Keep it so.
-- All three write both `statusLine` and `subagentStatusLine`, same hook file (`subagentStatusLine` appends a space + `subagent`). Path written quoted — command runs through a shell, so an unquoted home dir with spaces splits into two args. New entry point → wire into all three, not just document the snippet.
-- Uninstall: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our `statusLine`/`subagentStatusLine` (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command — only printed manual-removal instructions, which must list both keys too.
-- Don't reintroduce a "Full vs Lite" prompt or `statusline-lite.js` (deleted upstream `846e10e`). Only as a deliberate real feature.
+- All three write both `statusLine` and `subagentStatusLine` → same hook file (`subagentStatusLine` appends a space + `subagent`), path written quoted (the command runs through a shell, so an unquoted home dir with spaces splits into two args). New entry point → wire into all three, not just document the snippet.
+- Uninstall: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our two keys (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command, only printed manual-removal instructions — which must list both keys too.
+- No "Full vs Lite" prompt or `statusline-lite.js` (deleted upstream `846e10e`) unless reintroduced as a deliberate real feature.
 
 ## Distribution + releasing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 
 **Segment opt-out.** `CTXLINE_DISABLE` comma list parsed once into `DISABLED` (trimmed, lowercased). Recognized: `branch`, `effort`, `cost`, `task`, `usage` (H+W). `dir`/`model`/`context` always render; unknown names ignored. Disabling skips the work, not just the output — `usage` means no network/cache/credentials at all.
 
-**Responsive layout (`layout()`).** Visible width (ANSI stripped) > `COLUMNS - WIDTH_MARGIN` → two lines: line 1 dir/branch + model/effort + `C`; line 2 `H`/`W` + `$` + task. Wraps only when `COLUMNS` is a known positive int and line 2 is non-empty — unknown width, wide terminals, nothing to wrap all stay single-line. `outputFallback()` stays single-line.
+**Responsive layout (`layout()`).** Visible width (ANSI stripped) > `COLUMNS - WIDTH_MARGIN` → two lines: line 1 dir/branch + model/effort + `C`; line 2 `H`/`W` + `$` + task. Wraps only when `COLUMNS` is a known positive int and line 2 is non-empty — unknown width, wide terminals, nothing to wrap all stay single-line. `outputFallback()` stays single-line. `cols` is a parameter, never an env read, so `layout()`/`renderStatusLine()` have no side effects.
 
 **Segment sources + gotchas** (each best-effort):
 
@@ -59,27 +59,27 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 | task | newest `~/.claude/todos/<sessionId>*-agent-*.json` | `activeForm` of the `in_progress` todo |
 
 **Usage API.** `GET api.anthropic.com/api/oauth/usage`, bearer token + `anthropic-beta: oauth-2025-04-20`. Token from `getCredentials()`: `~/.claude/.credentials.json`, then macOS keychain. API-key users get no usage.
-- `parseUsagePayload(body)` — pure, no fs/network — turns a raw `/usage` response body into `{ fiveHour, weekly, models }`; `null` on unparseable JSON or a missing/non-finite `five_hour` utilization. `getApiUsage()` calls it, then owns only credentials/socket/timeout/cache-write.
-- `buildUsageFromStdin()` returns the same `{ fiveHour, weekly, models }` shape (`models` always `[]` — stdin never carries scoped limits), so both adapters feed `buildUsageBars(raw)` directly — one positional object, not three.
-- `getRawUsage()` → `{ fiveHour, weekly, models }`, cache-first; `buildUsageBars()` renders all three (`models` possibly empty). Checks a `lastAttempt` cooldown (`getLastAttemptAge()`, `FRESH_TTL_MS`) before calling `getApiUsage()` at all, so a failing/timed-out refresh backs off the same as a successful one instead of re-hitting the API on every render.
+- Both adapters return `{ fiveHour, weekly, models }` and feed `buildUsageBars(raw)` — one positional object. `buildUsageFromStdin()`'s `models` is always `[]` (stdin never carries scoped limits).
+- `parseUsagePayload(body)` — pure, no fs/network; `null` on unparseable JSON or a missing/non-finite `five_hour` utilization. `getApiUsage()` calls it and owns only credentials/socket/timeout/cache-write.
+- `getRawUsage()` is cache-first, and checks the `lastAttempt` cooldown (`getLastAttemptAge()`, `FRESH_TTL_MS`) before calling `getApiUsage()` at all → a failed/timed-out refresh backs off the same as a successful one.
 - `parseScopedLimits(usage)` reads `limits[]` for `kind: 'weekly_scoped'`; label = first initial of `scope.model.display_name` (new model family needs no code change). Legacy flat `seven_day_opus`/`seven_day_sonnet` only when `limits` yields nothing → neither shape double-counts.
-- Scoped limits never arrive via stdin → `resolveUsage()` calls `getRawUsage()` for the model-scoped bars even when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; slow/failed call costs only the scoped bars.
+- Scoped limits never arrive via stdin → `resolveUsage()` calls `getRawUsage()` for those bars even when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; slow/failed call costs only the scoped bars.
 
-Entry point guarded by `require.main === module` so `test/render.test.js` can `require()` it and call the exported pure functions directly instead of spawning: `renderStatusLine`/`renderSubagentTask` (format/colour-band/segment-order/wrap assertions) and `parseScopedLimits`/`parseUsagePayload`/`normalizePercentage` (the `/usage` payload shape is the one part stdin can't reach) — plus `readStdinThen` for the stdin-error test.
-
-`outputStatus` is a ~3-line writer: `collectFacts(data)` gathers everything that touches fs/child_process/env (git branch + ahead/behind, the in-progress task, `COLUMNS`), then the pure `renderStatusLine(data, facts, usage)` formats, wrapped in a try/catch that falls back to `Status unavailable`. `outputFallback` calls the same `renderStatusLine` with a static, git/task-free `facts` object (`cols: undefined` keeps it single-line, matching the always-single-line fallback contract). `layout()` takes `cols` as a parameter rather than reading `COLUMNS` itself, so it and `renderStatusLine` have no side effects.
+**Render seam.** `collectFacts(data)` gathers everything touching fs/child_process/env (git branch + ahead/behind, in-progress task, `COLUMNS`); pure `renderStatusLine(data, facts, usage)` formats; `outputStatus` is a ~3-line writer, try/catch → `Status unavailable`. `outputFallback` calls the same renderer with a static git/task-free `facts` (`cols: undefined` → single line, matching the fallback contract). Entry guarded by `require.main === module` so `test/render.test.js` can `require()` and call exports directly instead of spawning: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`.
 
 **Caches** (both in `~/.claude/cache/`):
-- `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10min. `lastAttempt` (success or failure, stamped by `recordUsageAttempt()` before the request fires) gives `getRawUsage()` a retry cooldown independent of `timestamp` — a failing/timing-out refresh backs off for `FRESH_TTL_MS` too, instead of re-hitting the API on every render. Bars re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
+- `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10min. `lastAttempt` — stamped by `recordUsageAttempt()` before the request fires, success or failure — is the retry cooldown, independent of `timestamp`. Bars re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
 - `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
 
 **Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg → several scoped bars read as one group while a nearly-spent one still stands out.
 
-**Deliberately duplicated, do not merge:** the two caches (`git-cache.json` / `usage-cache.json` via `readGitCache`/`writeGitCache` + `getGitAheadBehind` vs `readCachedUsage`/`setCachedUsage` + `getRawUsage`) and the two duration formatters (`buildUsageBar`'s countdown vs `formatElapsed`) each have only two callers with differing validators / units / refresh policies (git 5s/60s vs usage 30s/10m; countdown vs elapsed). A shared `withCache`/`formatDuration` would move complexity into parameters, not reduce it — revisit only on a third caller.
+**Deliberately duplicated, do not merge:** the two caches, and the two duration formatters (`buildUsageBar`'s countdown vs `formatElapsed`). Two callers each, differing validators / units / refresh policies (git 5s/60s vs usage 30s/10m; countdown vs elapsed) — a shared `withCache`/`formatDuration` moves complexity into parameters. Revisit only on a third caller.
+
+**Not actioned, deliberately:** the `lastAttempt` cooldown check (`getLastAttemptAge()`) and claim (`recordUsageAttempt()`) aren't atomic across processes — concurrent hook invocations can both call `getApiUsage()`. Worst case is one extra API call, never a crash or bad render; a filesystem lock plus a multi-process test contradicts the single-file, zero-dependency constraint. Revisit only if concurrent hook processes prove common.
 
 ## Subagent mode (`subagentStatusLine`)
 
-A second entry point in the same file, activated by `process.argv[2] === 'subagent'` — wired in `settings.json` as a separate command from `statusLine`:
+Second entry point in the same file, activated by `process.argv[2] === 'subagent'` — wired in `settings.json` as a separate command from `statusLine`:
 
 ```json
 { "subagentStatusLine": { "type": "command", "command": "node ~/.claude/hooks/statusline.js subagent" } }
@@ -90,11 +90,11 @@ One row per running subagent task in the agent panel.
 - Stdin: `{ tasks: [...], ... }` (base fields `session_id`/`cwd`/`columns` present but unused). Each task: `id`, `name`/`description`/`label`, `type`, `status`, `startTime`, `model` (resolved ID, absent until resolved), `effort` (level string or numeric token budget, absent when the subagent inherits session effort), `contextWindowSize`, `tokenCount`, `tokenSamples`, `cwd`.
 - Stdout: one `{"id","content"}` JSON line per task to override. Omitted id → default rendering; empty `content` → row hidden.
 
-`startTime`'s format isn't documented upstream and isn't otherwise read in this file, so `formatElapsed()` accepts whatever shows up: number < `1e12` → epoch-seconds, larger → epoch-ms, anything else handed straight to `Date()` (covers an ISO string). Revisit if a real payload contradicts this.
-
 Row: `name │ Model · effort │ C<used> <bar> │ ⏱ <elapsed>`, built by `renderSubagentTask()`. Reuses main-line blocks rather than duplicating: `SEGMENT_SEP`, `renderContextBar()` (used%→bar/color, factored out of `getContextBar`, shared by both), `getEffortColor()`. `shortenModelId()` shortens the resolved model *ID* ("claude-opus-5" → "Opus 5"; strips `us.`/`anthropic.` prefixes and a trailing `-YYYYMMDD` date) — distinct from `shortenModel()`, which only trims `" context)"` off a display *name*.
 
 Every segment past `name` is independently conditional: no `model` → no model/effort segment (effort alone still renders); no `effort` → no `· effort` suffix; `tokenCount`/`contextWindowSize` not both finite (or window ≤ 0) → no context bar; unparseable `startTime` → no elapsed segment.
+
+`startTime`'s format isn't documented upstream and isn't otherwise read in this file, so `formatElapsed()` accepts whatever shows up: number < `1e12` → epoch-seconds, larger → epoch-ms, anything else handed straight to `Date()` (covers an ISO string). Revisit if a real payload contradicts this.
 
 Skips everything main mode does besides stdin parsing — no usage API, git, todos, cache — so no `overallTimeout` race against a fetch; `emitSubagent()` hard-caps the stdin read at `SUBAGENT_TIMEOUT_MS`. Bad/missing payload, or a task whose shape breaks rendering → emit nothing rather than a partial line: default rendering stays for every task in the panel, process still exits 0.
 
@@ -102,22 +102,19 @@ Skips everything main mode does besides stdin parsing — no usage API, git, tod
 
 `statusline.js` is source of truth; five files mirror the visible line and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
 
-`test/fixture.js` — shared by both: fake-HOME construction, `usage-cache.json` seeding (via `statusline.js`'s own exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, and spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
+`test/fixture.js` — shared by test + preview: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
 
-Executable fixtures — stale = CI/release breaks:
-- `scripts/preview.js` — spawns the real `statusline.js` via `test/fixture.js` against a seeded cache + stdin JSON. Cache-shape change → update the seed data passed to `seedUsageCache` **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add to the input object. The release body shows `head -n 1` of its output → keep the primary-line `console.log` **first**.
+- `scripts/preview.js` — spawns the real `statusline.js` via the fixture against a seeded cache + stdin JSON. Cache-shape change → update the seed data passed to `seedUsageCache` **and** `render()` params/labels, or usage renders wrong/disappears. New stdin field read → add to the input object. The release body shows `head -n 1` of its output → keep the primary-line `console.log` **first**.
 - `test/render.test.js` — same fixture, same breakage; assertions pin visible labels/percentages/colors/order. `colors` codes change → update the constants atop the file.
-
-Docs/marketing — no longer silent, both auto-checked:
 - `docs/assets/preview.svg` — the statusline `<text>` elements' `<tspan>` runs; shown in README + site. Generated, not hand-edited: `npm run preview:svg` (`scripts/preview-svg.js`) renders the real ANSI output for the same fixed scenario and rewrites just those tspans (ANSI SGR → hex, via its own `ANSI_HEX` table); window chrome, prompt lines, and the "○ " running-task bullet stay hand-authored. Run it after any change that would shift this scenario's output (colors, thresholds, format).
-- `docs/index.html` — hero mock (`.term .line`) and the subagent-panel rows are asserted against a real `renderStatusLine()`/`renderSubagentTask()` call by `test/docs-drift.test.js` (reconstructs the mock's visible text from its markup, byte-compares). A mismatch fails `npm test`, not just a future changelog. Inspector `SIGNALS[]` and `.term` color classes are still unchecked — hand-verify those.
+- `docs/index.html` — hero mock (`.term .line`) and the subagent-panel rows are byte-compared against a real `renderStatusLine()`/`renderSubagentTask()` call by `test/docs-drift.test.js`, so site drift fails `npm test`. Inspector `SIGNALS[]` and `.term` color classes are still unchecked — hand-verify those.
 - `CLAUDE.md` — format diagram (top), segment-source table, visible contract below.
 
 Full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.
 
-Rule of thumb: change to **what the line looks like** → test assertions. Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
-
 Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar; `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
+
+Rule of thumb: change to **what the line looks like** → test assertions. Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
 
 Test harness: `run()` opts `columns` (unset → single line) and `disable` (→ `CTXLINE_DISABLE`); preview's `render()` takes matching params (narrow scenario 40, opt-out scenario `usage,cost`) plus `models` (`[{ label, percentage, resetsInMin }]`) for the scoped-limit scenario. Both clear `COLUMNS`/`CTXLINE_DISABLE` when unset so a dev-env value can't skew output. Git ahead/behind tests need real `git` (skipped if absent) and a fresh HOME per test (isolated `git-cache.json`).
 
@@ -130,10 +127,8 @@ Work in `statusline.js` only. Install path is frozen (inherited working from ups
 - Uninstall: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our `statusLine`/`subagentStatusLine` (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command — only printed manual-removal instructions, which must list both keys too.
 - Don't reintroduce a "Full vs Lite" prompt or `statusline-lite.js` (deleted upstream `846e10e`). Only as a deliberate real feature.
 
-## Distribution
+## Distribution + releasing
 
 `statusline.js` is fetched verbatim from GitHub `main` by `install.sh`/`install.ps1` (via `REPO_URL`) and copied by `bin/install.js`. A change on `main` ships to anyone re-running the installers — keep `main` releasable. `package.json` `files` whitelists what publishes.
 
-## Releasing
-
-Owner-triggered, manual: bump `version` in `package.json` on `main`, then run the **Release** workflow (`.github/workflows/release.yml`), which publishes from that version. Never `npm publish` by hand; never bump the version unasked.
+Releases are owner-triggered, manual: bump `version` in `package.json` on `main`, then run the **Release** workflow (`.github/workflows/release.yml`), which publishes from that version. Never `npm publish` by hand; never bump the version unasked.


### PR DESCRIPTION
Docs only. No `statusline.js` change, so no test/preview impact.

## Trim

Prose squeeze, no facts dropped (17.3K -> 16.1K):

- `## Distribution` + `## Releasing` merged into `## Distribution + releasing`.
- Export list folded into a new `**Render seam.**` paragraph; `serializeUsageCache` added to it (exported, previously only mentioned indirectly under keep-in-sync).
- `layout()`'s no-side-effects note moved up beside the layout rules.
- Usage API bullets reordered so the shared `{ fiveHour, weekly, models }` shape leads; refactor narration compressed.
- Keep-in-sync: dropped the "Executable fixtures" / "Docs/marketing" sub-headers for one flat list.
- Do-not-merge paragraph dropped a function-name enumeration already listed elsewhere; verdict and third-caller trigger kept.

## Added

`**Not actioned, deliberately:**` — the `lastAttempt` cooldown check (`getLastAttemptAge()`) and claim (`recordUsageAttempt()`) aren't atomic across processes, so concurrent hook invocations can both call `getApiUsage()`. Accepted on #43: worst case one extra API call, never a crash or bad render; a filesystem lock plus a multi-process test contradicts the single-file, zero-dependency constraint.

That decision only lived in #43's review thread and in local working notes that are about to be deleted, so it's recorded next to the other "do not re-propose this" guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified responsive layout behavior, usage parsing, and side-effect-free rendering.
  * Documented statusline cache data, standard input fields, subagent rendering, and synchronized updates across related resources.
  * Added guidance for test harness options, fixtures, environment cleanup, scoped limits, and Git prerequisites.
  * Reorganized release and distribution guidance, consolidated non-goals, and improved overall readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->