### PR TITLE
feat: weekly npm update check with an upgrade-command row

### DIFF
--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -24,7 +24,7 @@ After edits: `npm test` + `npm run preview` + `npm run preview:svg`. All must pa
 
 ```text
 dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 ↺ 4h20m │ W31 ↺ 2d13h │ F86 ↺ 2d13h │ $44.21 │ task
-⬆ update 1.7.0 · run: npx ctxline-claude@latest
+⬆ 1.7.0 available · npx ctxline-claude@latest
 ```
 
 - Labels fused with percent: `C`=context, `H`=5h, `W`=7d, `<initial>`=model-scoped weekly limit (Fable → `F`, label derived from `scope.model.display_name` in `parseScopedLimits` — never hardcode a model list).
@@ -32,7 +32,7 @@ dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 �
 - Labels live INSIDE the builder functions (`getContextBar`/`buildUsageBar`), not as prefixes in `renderStatusLine`. `renderStatusLine` pushes segments verbatim; `outputStatus`/`outputFallback` are thin writers that call it.
 - `↑N↓M` is appended to the branch string (↑ green / ↓ red), not a separate segment. Zero side omitted.
 - `$<cost>` is dim, sits after usage and before task.
-- The `⬆` row is **not a segment**. `renderUpdateLine(latest)` builds it and `renderStatusLine` appends it after `layout()`, so it never affects wrap math. Green `⬆` + new version, dim connective, bold command. Conditional and rare — only when `update-cache.json` holds a `latest` strictly newer than `VERSION`. Cache-only on the render path; the fetch runs in the detached `update-check` entry point.
+- The `⬆` row is **not a segment**. `renderUpdateLine(latest)` builds it and `renderStatusLine` appends it after `layout()`, so it never affects wrap math. Green `⬆ <version>`, dim `available ·`, bold command. Conditional and rare — only when `update-cache.json` holds a `latest` strictly newer than `VERSION`. Cache-only on the render path; the fetch runs in the detached `update-check` entry point.
 - Consts: `BAR_WIDTH` 6 (bar cells), `SEGMENT_SEP` `' │ '`, `MAX_BRANCH_LEN` 24, `WIDTH_MARGIN` 0.
 
 ## Responsive wrap — reassign segments when order changes

--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -11,7 +11,7 @@ description: Change the statusline's visible design — layout, segment format, 
 
 | File | What to change | Where |
 |---|---|---|
-| `statusline.js` | render logic — source of truth | `getContextBar`, `buildUsageBar`, `buildUsageBars`, `formatAheadBehind`, `getCostSegment`, `layout`, `collectFacts`, `renderStatusLine`, `outputStatus`, `outputFallback` |
+| `statusline.js` | render logic — source of truth | `getContextBar`, `buildUsageBar`, `buildUsageBars`, `formatAheadBehind`, `getCostSegment`, `getLatestUpdate`, `renderUpdateLine`, `layout`, `collectFacts`, `renderStatusLine`, `outputStatus`, `outputFallback` |
 | `test/render.test.js` | assertions on labels / `NN%` / colors / order | match new label regexes (e.g. `/C\d+ /`, `/H\d+\b/`); ANSI const block near top |
 | `scripts/preview.js` | seed + render check | cache seed data (via `test/fixture.js`'s `seedUsageCache`), `render()` params (`columns`, `disable`); **primary `console.log` stays FIRST line** (release takes `head -n 1`) |
 | `docs/assets/preview.svg` | marketing SVG (README/site) | 2 of its 12 `<text>` elements (main statusline + subagent row) are **generated**, not hand-edited — run `npm run preview:svg` after any output-shape change; the other 10 (window chrome, prompt lines, bullets) stay hand-authored |
@@ -24,6 +24,7 @@ After edits: `npm test` + `npm run preview` + `npm run preview:svg`. All must pa
 
 ```text
 dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 ↺ 4h20m │ W31 ↺ 2d13h │ F86 ↺ 2d13h │ $44.21 │ task
+⬆ update 1.7.0 · run: npx ctxline-claude@latest
 ```
 
 - Labels fused with percent: `C`=context, `H`=5h, `W`=7d, `<initial>`=model-scoped weekly limit (Fable → `F`, label derived from `scope.model.display_name` in `parseScopedLimits` — never hardcode a model list).
@@ -31,6 +32,7 @@ dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 �
 - Labels live INSIDE the builder functions (`getContextBar`/`buildUsageBar`), not as prefixes in `renderStatusLine`. `renderStatusLine` pushes segments verbatim; `outputStatus`/`outputFallback` are thin writers that call it.
 - `↑N↓M` is appended to the branch string (↑ green / ↓ red), not a separate segment. Zero side omitted.
 - `$<cost>` is dim, sits after usage and before task.
+- The `⬆` row is **not a segment**. `renderUpdateLine(latest)` builds it and `renderStatusLine` appends it after `layout()`, so it never affects wrap math. Green `⬆` + new version, dim connective, bold command. Conditional and rare — only when `update-cache.json` holds a `latest` strictly newer than `VERSION`. Cache-only on the render path; the fetch runs in the detached `update-check` entry point.
 - Consts: `BAR_WIDTH` 6 (bar cells), `SEGMENT_SEP` `' │ '`, `MAX_BRANCH_LEN` 24, `WIDTH_MARGIN` 0.
 
 ## Responsive wrap — reassign segments when order changes
@@ -39,6 +41,7 @@ dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 �
 
 - line 1 = dir/branch + model/effort + `C`
 - line 2 = `H`/`W`/scoped + `$` + task
+- the `⬆` row, when present, is appended below both — a 3rd row on a narrow terminal
 
 Adding or moving a segment means picking its line in `renderStatusLine`, not just its position. Wrap fires only when `cols` is a known positive int **and** line 2 is non-empty. `outputFallback()` stays single-line — it calls `renderStatusLine` with a static `facts.cols: undefined`, which `layout` treats as unknown width.
 
@@ -46,7 +49,7 @@ Adding or moving a segment means picking its line in `renderStatusLine`, not jus
 
 ## Opt-out names are part of the visible contract
 
-`CTXLINE_DISABLE` recognizes `branch`, `effort`, `cost`, `task`, `usage` (H+W). Renaming a segment → update the `DISABLED` checks, the test `disable` opt, preview's opt-out scenario (passes `usage,cost`), and the docs. `dir`/`model`/`context` are never disableable.
+`CTXLINE_DISABLE` recognizes `branch`, `effort`, `cost`, `task`, `update`, `usage` (H+W). Renaming a segment → update the `DISABLED` checks, the test `disable` opt, preview's opt-out scenario (passes `usage,cost`), and the docs. `dir`/`model`/`context` are never disableable.
 
 ## Colors (two schemes — do NOT unify)
 
@@ -79,6 +82,7 @@ Ahead/behind: both the site (`.ahead` green / `.behind` `#f85149`) and `statusli
 `test/fixture.js` backs both `test/render.test.js` and `scripts/preview.js`: fake-HOME construction, `usage-cache.json` seeding (through `statusline.js`'s exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside `package.json`'s `files` whitelist.
 
 - `run()` opts: `columns` (unset → single line), `disable` (→ `CTXLINE_DISABLE`).
+- `makeHome()` seeds a `latest`-less `update-cache.json` stamped now — keeps tests offline (no registry child spawns) and shows no nudge. `seedUpdateCache(home, { latest, checkedAt, lastAttempt })` overrides it; preview's `render()` takes `update: '<version>'` for the same thing.
 - Preview's `render()` takes the matching params — narrow scenario passes 40, opt-out scenario passes `usage,cost` — plus `models` (`[{ label, percentage, resetsInMin }]`) for the scoped-limit scenario.
 - Both clear `COLUMNS`/`CTXLINE_DISABLE` when unset, so a dev-env value can't skew output.
 - Git ahead/behind tests need real `git` (skipped if absent) and a fresh HOME per test, to isolate `git-cache.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ npm package `ctxline-claude` — single-file statusline for Claude Code:
 
 ```text
 dir ⎇ branch ↑N↓M │ model · effort │ C<used> <bar> │ H<pct> ↺ <reset> │ W<pct> ↺ <reset> │ <model-initial><pct> ↺ <reset> │ $<cost> │ task
-⬆ update <latest> · run: npx ctxline-claude@latest
+⬆ <latest> available · npx ctxline-claude@latest
 ```
 
 `C` context (only segment with a bar), `H` 5-hour usage, `W` 7-day usage, `<model-initial>` model-scoped weekly limit (Fable → `F`), `$` session cost. Everything after `dir`/`model`/`C` is conditional — renders only when its source resolves. The `⬆` row is **not a segment** — it's appended below whatever the layout produced, only when a newer release is cached.
@@ -128,7 +128,7 @@ Triggers: change to **what the line looks like** → test assertions (+ `npm run
 
 Full edit-point map, test-harness options, and the ANSI/SVG color tables: `.claude/skills/restyle-statusline/SKILL.md`.
 
-Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar glyph (`buildUsageBar` builds text-only `H`/`W`/scoped segments despite the name); `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; the `⬆` row appended below the layout (green `⬆` + new version, dim connective, bold command), never inside it; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
+Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar glyph (`buildUsageBar` builds text-only `H`/`W`/scoped segments despite the name); `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; the `⬆` row appended below the layout (green `⬆ <version>`, dim `available ·`, bold command), never inside it; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
 
 ## Do not touch the installers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ npm package `ctxline-claude` — single-file statusline for Claude Code:
 
 ```text
 dir ⎇ branch ↑N↓M │ model · effort │ C<used> <bar> │ H<pct> ↺ <reset> │ W<pct> ↺ <reset> │ <model-initial><pct> ↺ <reset> │ $<cost> │ task
+⬆ update <latest> · run: npx ctxline-claude@latest
 ```
 
-`C` context (only segment with a bar), `H` 5-hour usage, `W` 7-day usage, `<model-initial>` model-scoped weekly limit (Fable → `F`), `$` session cost. Everything after `dir`/`model`/`C` is conditional — renders only when its source resolves.
+`C` context (only segment with a bar), `H` 5-hour usage, `W` 7-day usage, `<model-initial>` model-scoped weekly limit (Fable → `F`), `$` session cost. Everything after `dir`/`model`/`C` is conditional — renders only when its source resolves. The `⬆` row is **not a segment** — it's appended below whatever the layout produced, only when a newer release is cached.
 
 ## Commands
 
@@ -23,6 +24,9 @@ npm pack --dry-run # preview what publishes
 
 # Main line — the stdin JSON Claude Code sends:
 echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp/x"},"session_id":"t","context_window":{"remaining_percentage":40}}' | node statusline.js
+
+# Update check (detached child; writes ~/.claude/cache/update-cache.json, prints nothing):
+node statusline.js update-check
 
 # Subagent rows (startTime = 4m12s ago, epoch seconds — format note below):
 echo '{"tasks":[{"id":"t1","name":"reviewer","model":"claude-opus-5","effort":"max","tokenCount":45200,"contextWindowSize":200000,"startTime":'$(($(date +%s)-252))'}]}' | node statusline.js subagent
@@ -40,7 +44,7 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 
 **Timing is load-bearing.** stdin raced against `overallTimeout` (500ms with `ANTHROPIC_API_KEY`, else 1300/1600ms by cache presence); first to fire prints and `exit(0)`. Usage API has its own timeout (1200ms warm / 1500ms cold) and fires only on the fallback path.
 
-**Segment opt-out.** `CTXLINE_DISABLE` comma list parsed once into `DISABLED` (trimmed, lowercased). Recognized: `branch`, `effort`, `cost`, `task`, `usage` (H+W). `dir`/`model`/`context` always render; unknown names ignored. Disabling skips the work, not just the output — `usage` means no network/cache/credentials at all.
+**Segment opt-out.** `CTXLINE_DISABLE` comma list parsed once into `DISABLED` (trimmed, lowercased). Recognized: `branch`, `effort`, `cost`, `task`, `update`, `usage` (H+W). `dir`/`model`/`context` always render; unknown names ignored. Disabling skips the work, not just the output — `usage` means no network/cache/credentials at all.
 
 **Responsive layout (`layout()`).** Visible width (ANSI stripped) > `COLUMNS - WIDTH_MARGIN` → two lines: line 1 dir/branch + model/effort + `C`; line 2 `H`/`W` + `$` + task. Fires only when `COLUMNS` is a known positive int and line 2 is non-empty — unknown width, wide terminal, or nothing to wrap stays single-line, as does `outputFallback()`. `cols` is a parameter, never an env read, so `layout()`/`renderStatusLine()` have no side effects.
 
@@ -55,6 +59,7 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 | `$` | stdin `cost.total_cost_usd`, no network/cache | `Number.isFinite`-guarded; client-side estimate at API pricing — for subscription users, not actual billing |
 | `H` / `W` | stdin `rate_limits` via `buildUsageFromStdin()`, else `getRawUsage()` → OAuth API | `rate_limits` exists only for Claude.ai Pro/Max **after the first API response** — absent at cold start and for API-key users, hence the fallback |
 | scoped weekly | OAuth API only | never arrives via stdin; `getScopedColor` (orange, red ≥90), not the H/W thresholds |
+| `⬆` row | `update-cache.json` only — never the network on the render path | `getLatestUpdate()` compares the cached `latest` against `VERSION`; `''` unless strictly newer, and both sides must be strict `x.y.z` (a prerelease never nudges). `renderUpdateLine()` appends it *after* `layout()`, so it never competes for width and never joins the wrap decision |
 | task | newest `~/.claude/todos/<sessionId>*-agent-*.json` | `activeForm` of the `in_progress` todo |
 
 **Usage API.** `GET api.anthropic.com/api/oauth/usage`, bearer token + `anthropic-beta: oauth-2025-04-20`. Token from `getCredentials()`: `~/.claude/.credentials.json`, then macOS keychain. API-key users get no usage.
@@ -64,10 +69,19 @@ Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `
 - `parseScopedLimits(usage)` reads `limits[]` for `kind: 'weekly_scoped'`; label = first initial of `scope.model.display_name` (new model family needs no code change). Legacy flat `seven_day_opus`/`seven_day_sonnet` only when `limits` yields nothing → neither shape double-counts.
 - `resolveUsage()` still calls `getRawUsage()` for the scoped bars when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; a slow/failed call costs only those bars.
 
-**Render seam.** `collectFacts(data)` gathers everything touching fs/child_process/env (git branch + ahead/behind, in-progress task, `COLUMNS`); pure `renderStatusLine(data, facts, usage)` formats; `outputStatus` is a ~3-line writer, try/catch → `Status unavailable`. `outputFallback` calls the same renderer with a static git/task-free `facts` (`cols: undefined` → single line, matching the fallback contract). Entry guarded by `require.main === module` so `test/render.test.js` can `require()` and call exports directly instead of spawning: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`.
+**Update check.** `GET registry.npmjs.org/ctxline-claude/latest` → `parseRegistryVersion(body)` (pure; `null` on anything but strict `x.y.z`). Anonymous — no credentials, no session data.
+- Rendered as its **own stdout row** (Claude Code renders each line as a separate row), not a segment: the copy-pasteable `npx ctxline-claude@latest` is too wide to inline without forcing the main line to wrap on most terminals. `npx <pkg>@latest` is correct for `install.sh`/`install.ps1` users too — it recopies the hook.
+- **Render never fetches.** `emit()` calls `refreshUpdateCheck()` → spawns a **detached** `node statusline.js update-check` child (`stdio: 'ignore'`, `.unref()`), returns immediately. Parent exits on its usual stdin race; child writes the cache ~300ms later, so the nudge shows on the next render. Blocking inline would break the timing contract for a segment nobody waits on.
+- `lastAttempt` stamped **before** the spawn → offline machine / failed spawn / killed child backs off `UPDATE_RETRY_MS` (1h) instead of respawning per render. Success stamps `checkedAt` → next check gated by `UPDATE_TTL_MS` (7 days). Failure leaves `checkedAt` untouched, so the 1h backoff governs, not the weekly one.
+- Interval, not calendar-pinned. "7 days since last success" needs no date math; drift is harmless.
+- `VERSION` constant lives in `statusline.js`: installers copy that file alone into `~/.claude/hooks/`, no `package.json` beside it at runtime. **Bump it with `package.json`** — see keep-in-sync below.
+- `CTXLINE_DISABLE=update` skips cache read and spawn entirely.
 
-**Caches** (both in `~/.claude/cache/`):
+**Render seam.** `collectFacts(data)` gathers everything touching fs/child_process/env (git branch + ahead/behind, in-progress task, cached update version, `COLUMNS`); pure `renderStatusLine(data, facts, usage)` formats; `outputStatus` is a ~3-line writer, try/catch → `Status unavailable`. `outputFallback` calls the same renderer with a static git/task-free `facts` (`cols: undefined` → single line, matching the fallback contract). Entry guarded by `require.main === module` so `test/render.test.js` can `require()` and call exports directly instead of spawning: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`, `compareVersions`, `parseRegistryVersion`.
+
+**Caches** (all in `~/.claude/cache/`):
 - `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10m. `lastAttempt` — stamped by `recordUsageAttempt()` before the request fires, success or failure — is the retry cooldown, independent of `timestamp`. Segments re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
+- `update-cache.json` — `{ latest, checkedAt, lastAttempt }`, all optional. Written by the detached `update-check` child (`latest` + `checkedAt`) and by `refreshUpdateCheck()` (`lastAttempt` only). Read-only on the render path. Shared across sessions like the others.
 - `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
 
 **Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg → several scoped bars read as one group while a nearly-spent one still stands out.
@@ -97,7 +111,7 @@ Skips everything main mode does besides stdin parsing — no usage API, git, tod
 
 ## Keep in sync when `statusline.js` changes
 
-`statusline.js` is source of truth; the five files below mirror the visible line and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
+`statusline.js` is source of truth; the six files below mirror it and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
 
 | file | mirrors | trap |
 |---|---|---|
@@ -106,14 +120,15 @@ Skips everything main mode does besides stdin parsing — no usage API, git, tod
 | `docs/assets/preview.svg` | the statusline `<text>` elements' `<tspan>` runs (README + site) | generated, never hand-edited — run `npm run preview:svg` after anything that shifts this scenario's output; window chrome, prompt lines, and the "○ " bullet stay hand-authored |
 | `docs/index.html` | hero mock (`.term .line`) + subagent-panel rows | byte-compared against real `renderStatusLine()`/`renderSubagentTask()` calls by `test/docs-drift.test.js`, so drift fails `npm test`; inspector `SIGNALS[]` and `.term` color classes are unchecked — hand-verify |
 | `CLAUDE.md` | format diagram (top), segment-source table, visible contract below | — |
+| `package.json` | `version` ↔ the `VERSION` constant in `statusline.js` | not a visible-line mirror, but the same class of drift: a stale `VERSION` makes every installed copy nudge for an update forever (or never) |
 
-`test/fixture.js` is the shared harness behind test + preview, not one of the five: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
+`test/fixture.js` is the shared harness behind test + preview, not one of the six: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), `update-cache.json` seeding (`makeHome()` stamps a `latest`-less one so tests never spawn the registry child), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
 
-Triggers: change to **what the line looks like** → test assertions (+ `npm run preview:svg`). Change to **cache shape or stdin fields** → both seeds. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
+Triggers: change to **what the line looks like** → test assertions (+ `npm run preview:svg`). Change to **cache shape or stdin fields** → both seeds. Version bump → `VERSION` in `statusline.js` too. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
 
 Full edit-point map, test-harness options, and the ANSI/SVG color tables: `.claude/skills/restyle-statusline/SKILL.md`.
 
-Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar glyph (`buildUsageBar` builds text-only `H`/`W`/scoped segments despite the name); `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
+Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar glyph (`buildUsageBar` builds text-only `H`/`W`/scoped segments despite the name); `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; the `⬆` row appended below the layout (green `⬆` + new version, dim connective, bold command), never inside it; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
 
 ## Do not touch the installers
 
@@ -128,4 +143,4 @@ Work in `statusline.js` only. Install path is frozen (inherited working from ups
 
 `statusline.js` is fetched verbatim from GitHub `main` by `install.sh`/`install.ps1` (via `REPO_URL`) and copied by `bin/install.js`. A change on `main` ships to anyone re-running the installers — keep `main` releasable. `package.json` `files` whitelists what publishes.
 
-Releases are owner-triggered, manual: bump `version` in `package.json` on `main`, then run the **Release** workflow (`.github/workflows/release.yml`), which publishes from that version. Never `npm publish` by hand; never bump the version unasked.
+Releases are owner-triggered, manual: bump `version` in `package.json` **and the `VERSION` constant in `statusline.js`** on `main`, then run the **Release** workflow (`.github/workflows/release.yml`), which publishes from that version. Never `npm publish` by hand; never bump the version unasked.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ No, it's imperceptible. Almost every render reads a small local cache (sub-milli
 <details>
 <summary>What is the ⬆ segment, and what does it send?</summary>
 
-An extra row appears below the statusline — `⬆ 1.7.0 available · npx ctxline-claude@latest` — so the upgrade command is right there to copy. It shows only while you're behind, and the command works whichever way you installed. Once a week a short-lived background process asks the public npm registry for the package's latest version number and writes it to a local cache; the statusline itself only ever reads that cache, so no render waits on the network. The request carries nothing about you — no session data, no identifiers, just a plain GET for a public package. Hide it (and skip the request entirely) with `CTXLINE_DISABLE=update`.
+An extra row appears below the statusline — `⬆ 1.7.0 available · npx ctxline-claude@latest` — so the upgrade command is right there to copy. It shows only while you're behind, and the command works whichever way you installed. Once a week a short-lived background process asks the public npm registry for the package's latest version number and writes it to a local cache; the statusline itself only ever reads that cache, so no render waits on the network. The request carries no session data, credentials, or identifiers — it's a plain GET for a public package, though as with any HTTP request the registry does see your IP address. Hide it (and skip the request entirely) with `CTXLINE_DISABLE=update`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 | **Model limit** | Weekly limit scoped to a single model, when your account has one — labelled by the model's initial (`F` = Fable) |
 | **Cost** | Running session cost in USD (e.g. `$0.42`) |
 | **Task** | The in-progress todo, when there is one |
+| **Update** | An extra row with the upgrade command when a newer release is on npm — checked once a week, in the background |
 
 > [!NOTE]
 > Usage bars change color automatically as you approach your limits.
@@ -151,7 +152,7 @@ Remove-Item "$env:USERPROFILE\.claude\cache\usage-cache.json" -ErrorAction Silen
 
 The statusline is zero-config by default. To **hide segments you don't want**, set the `CTXLINE_DISABLE` environment variable to a comma-separated list of any of:
 
-`branch` · `effort` · `cost` · `task` · `usage` (5-hour + weekly + model-scoped)
+`branch` · `effort` · `cost` · `task` · `update` · `usage` (5-hour + weekly + model-scoped)
 
 Directory, model, and context always show; unknown names are ignored. Example below hides cost and the current task.
 
@@ -215,6 +216,13 @@ No — zero tokens, ever. The statusline is part of Claude Code's UI; its output
 <summary>Does fetching data slow down Claude Code?</summary>
 
 No, it's imperceptible. Almost every render reads a small local cache (sub-millisecond) instead of fetching. The usage API only runs as a fallback (and is cached); the git ahead/behind check runs at most once every ~5s and is hard-capped so it can never hang. The statusline runs as its own background command, so it never blocks your typing or Claude's responses — and in a non-git folder the git check doesn't run at all.
+
+</details>
+
+<details>
+<summary>What is the ⬆ segment, and what does it send?</summary>
+
+An extra row appears below the statusline — `⬆ update 1.7.0 · run: npx ctxline-claude@latest` — so the upgrade command is right there to copy. It shows only while you're behind, and the command works whichever way you installed. Once a week a short-lived background process asks the public npm registry for the package's latest version number and writes it to a local cache; the statusline itself only ever reads that cache, so no render waits on the network. The request carries nothing about you — no session data, no identifiers, just a plain GET for a public package. Hide it (and skip the request entirely) with `CTXLINE_DISABLE=update`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ No, it's imperceptible. Almost every render reads a small local cache (sub-milli
 <details>
 <summary>What is the ⬆ segment, and what does it send?</summary>
 
-An extra row appears below the statusline — `⬆ update 1.7.0 · run: npx ctxline-claude@latest` — so the upgrade command is right there to copy. It shows only while you're behind, and the command works whichever way you installed. Once a week a short-lived background process asks the public npm registry for the package's latest version number and writes it to a local cache; the statusline itself only ever reads that cache, so no render waits on the network. The request carries nothing about you — no session data, no identifiers, just a plain GET for a public package. Hide it (and skip the request entirely) with `CTXLINE_DISABLE=update`.
+An extra row appears below the statusline — `⬆ 1.7.0 available · npx ctxline-claude@latest` — so the upgrade command is right there to copy. It shows only while you're behind, and the command works whichever way you installed. Once a week a short-lived background process asks the public npm registry for the package's latest version number and writes it to a local cache; the statusline itself only ever reads that cache, so no render waits on the network. The request carries nothing about you — no session data, no identifiers, just a plain GET for a public package. Hide it (and skip the request entirely) with `CTXLINE_DISABLE=update`.
 
 </details>
 

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -8,7 +8,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const {
-  makeHome, seedCredentials, seedUsageCache, seedFakeRepo, seedDivergedRepo, spawnMain, spawnSubagent
+  makeHome, seedCredentials, seedUsageCache, seedUpdateCache, seedFakeRepo, seedDivergedRepo, spawnMain, spawnSubagent
 } = require('../test/fixture.js');
 
 // makeHome() creates each scenario's home independently (os.tmpdir()-rooted, not nested
@@ -33,9 +33,12 @@ function setupDivergedRepo(projectDir, branch) {
   }
 }
 
-function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, models, branch, effort, rateLimits, cost, columns, diverged, disable }) {
+function render({ dir, model, remaining, current, currentResetsInMin, weekly, weeklyResetsInMin, models, branch, effort, rateLimits, cost, columns, diverged, disable, update }) {
   const home = makeHome();
   HOMES.push(home);
+  // makeHome() already seeds a latest-less, freshly-stamped update cache (no registry
+  // child, no nudge); `update` overwrites it with a newer version to show the segment.
+  if (update) seedUpdateCache(home, { latest: update });
   // Only H/W bypass the cache: with rateLimits and no models, seed neither creds nor cache,
   // proving that path needs no network. Model-scoped bars never arrive via stdin, so seed a
   // fresh cache whenever `models` is set — rateLimits or not (statusline.js reads both).
@@ -161,6 +164,12 @@ console.log('  ' + render({
 // Segment opt-out: CTXLINE_DISABLE hides segments (dir/model/context always render).
 console.log('\nSegment opt-out (CTXLINE_DISABLE=usage,cost):');
 console.log('  ' + render({ ...base, effort: 'high', disable: 'usage,cost' }));
+
+// Update nudge: a weekly background check caches npm's latest version; when that is newer
+// than the running one, an extra row carrying the upgrade command is appended below the
+// statusline. Cache-only on the render path — the fetch runs in a detached child.
+console.log('\nUpdate available (cached newer npm version):');
+console.log('  ' + render({ ...base, effort: 'high', update: '9.9.9' }));
 
 // Subagent panel (subagentStatusLine mode): separate entry point (`node statusline.js
 // subagent`), separate stdin shape ({ tasks: [...] }), no cache/HOME seeding needed since

--- a/statusline.js
+++ b/statusline.js
@@ -66,7 +66,7 @@ const GIT_TIMEOUT_MS = 500;             // hard cap on the rev-list subprocess (
 const UPDATE_CACHE_FILE = path.join(CACHE_DIR, 'update-cache.json');
 const UPDATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;  // 7 days between successful checks
 const UPDATE_RETRY_MS = 60 * 60 * 1000;         // 1h backoff after a failed/killed check
-const UPDATE_TIMEOUT_MS = 2000;                 // child only, never on the render path
+const UPDATE_TIMEOUT_MS = 2000;                 // socket idle AND whole-request deadline
 const REGISTRY_HOST = 'registry.npmjs.org';
 const PACKAGE_NAME = 'ctxline-claude';
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;       // releases only: a prerelease never nudges
@@ -589,7 +589,13 @@ function refreshUpdateCheck() {
 // mode, and its stdio is discarded by the parent anyway. A failed fetch leaves checkedAt
 // untouched, so the UPDATE_RETRY_MS backoff (not the weekly TTL) governs the next try.
 function runUpdateCheck() {
+  let settled = false;
+  let deadline;
+
   const done = (latest) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(deadline);
     if (latest) writeUpdateCache({ ...(readUpdateCache() || {}), latest, checkedAt: Date.now() });
     process.exit(0);
   };
@@ -612,6 +618,14 @@ function runUpdateCheck() {
       req.destroy();
       done(null);
     });
+
+    // The `timeout` option above is socket inactivity, not total duration -- a response
+    // that trickles bytes would keep this detached child alive indefinitely, and the
+    // parent's UPDATE_RETRY_MS only delays the next spawn, it can't reap this one.
+    deadline = setTimeout(() => {
+      req.destroy();
+      done(null);
+    }, UPDATE_TIMEOUT_MS);
 
     req.end();
   } catch (e) {

--- a/statusline.js
+++ b/statusline.js
@@ -805,10 +805,8 @@ function collectFacts(data) {
 // `npx <pkg>@latest` is the right command for script-installed users too — it recopies the
 // hook. Only the target version is shown — the running one is what you're looking at.
 function renderUpdateLine(latest) {
-  return `${colors.green}⬆${colors.reset} `
-    + `${colors.dim}update${colors.reset} `
-    + `${colors.green}${latest}${colors.reset} `
-    + `${colors.dim}· run:${colors.reset} `
+  return `${colors.green}⬆ ${latest}${colors.reset} `
+    + `${colors.dim}available ·${colors.reset} `
     + `${colors.bold}npx ${PACKAGE_NAME}@latest${colors.reset}`;
 }
 

--- a/statusline.js
+++ b/statusline.js
@@ -8,12 +8,18 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const https = require('https');
-const { execSync, execFileSync } = require('child_process');
+const { execSync, execFileSync, spawn } = require('child_process');
+
+// Installed version, compared against the npm registry's latest for the update nudge.
+// This file is copied standalone into ~/.claude/hooks/ with no package.json beside it,
+// so the version has to live here. Must match package.json "version" (see CLAUDE.md).
+const VERSION = '1.6.2';
 
 const IS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
 
 // Optional segment opt-out: CTXLINE_DISABLE is a comma list of segments to hide.
-// Recognized: branch, effort, cost, task, usage (H+W+model-scoped). dir/model/context always render.
+// Recognized: branch, effort, cost, task, update, usage (H+W+model-scoped). dir/model/context
+// always render.
 // Unknown names are ignored. Disabling a segment also skips its work (git, todo read,
 // usage fetch).
 const DISABLED = new Set(
@@ -53,6 +59,17 @@ const GIT_CACHE_FILE = path.join(CACHE_DIR, 'git-cache.json');
 const GIT_FRESH_TTL_MS = 5000;          // 5s: reuse counts within a render burst
 const GIT_STALE_TTL_MS = 60000;         // 60s: fall back to last counts if git fails
 const GIT_TIMEOUT_MS = 500;             // hard cap on the rev-list subprocess (warm ~130ms)
+
+// Update check: compares VERSION against the npm registry's dist-tags.latest. The render
+// only ever reads this cache; the refresh runs in a detached child (see refreshUpdateCheck),
+// so no render ever waits on the registry.
+const UPDATE_CACHE_FILE = path.join(CACHE_DIR, 'update-cache.json');
+const UPDATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;  // 7 days between successful checks
+const UPDATE_RETRY_MS = 60 * 60 * 1000;         // 1h backoff after a failed/killed check
+const UPDATE_TIMEOUT_MS = 2000;                 // child only, never on the render path
+const REGISTRY_HOST = 'registry.npmjs.org';
+const PACKAGE_NAME = 'ctxline-claude';
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;       // releases only: a prerelease never nudges
 
 // Subagent mode reads only stdin (no usage API to race), so its stdin read gets a
 // short hard cap of its own instead of the main-mode overallTimeout.
@@ -497,6 +514,111 @@ function recordUsageAttempt() {
   }
 }
 
+// Compare two strict "x.y.z" versions -> -1 | 0 | 1, or null when either side isn't that
+// shape (prerelease tags, missing parts, non-numeric). The nudge is a nicety, so an
+// unparseable version means no segment rather than a guess.
+function compareVersions(a, b) {
+  const parse = (v) => SEMVER_RE.test(String(v ?? '')) ? String(v).split('.').map(Number) : null;
+  const x = parse(a);
+  const y = parse(b);
+  if (!x || !y) return null;
+  for (let i = 0; i < 3; i++) {
+    if (x[i] !== y[i]) return x[i] > y[i] ? 1 : -1;
+  }
+  return 0;
+}
+
+// Pure: an npm registry version-manifest body -> its "x.y.z" version string, or null on
+// unparseable JSON, a missing version, or a non-release version (404 bodies land here too).
+function parseRegistryVersion(body) {
+  try {
+    const v = JSON.parse(body)?.version;
+    return SEMVER_RE.test(String(v ?? '')) ? String(v) : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function readUpdateCache() {
+  try {
+    const c = JSON.parse(fs.readFileSync(UPDATE_CACHE_FILE, 'utf8'));
+    return c && typeof c === 'object' ? c : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function writeUpdateCache(obj) {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
+    fs.writeFileSync(UPDATE_CACHE_FILE, JSON.stringify(obj), 'utf8');
+  } catch (e) {}
+}
+
+// The cached latest version when it's newer than VERSION, else ''. Cache-only by design:
+// collectFacts calls this on the render path, and the render must never touch the network.
+function getLatestUpdate() {
+  const cached = readUpdateCache();
+  if (!cached) return '';
+  return compareVersions(cached.latest, VERSION) === 1 ? String(cached.latest) : '';
+}
+
+// Fire the weekly check in a detached child, so the render neither waits on the registry
+// nor races its own exit against the response. lastAttempt is stamped before the spawn, so
+// an offline machine, a failed spawn, or a child that dies backs off UPDATE_RETRY_MS
+// instead of respawning on every render.
+function refreshUpdateCheck() {
+  try {
+    const cached = readUpdateCache();
+    const now = Date.now();
+    if (cached) {
+      if (Number.isFinite(cached.checkedAt) && now - cached.checkedAt < UPDATE_TTL_MS) return;
+      if (Number.isFinite(cached.lastAttempt) && now - cached.lastAttempt < UPDATE_RETRY_MS) return;
+    }
+    writeUpdateCache({ ...(cached || {}), lastAttempt: now });
+    // windowsHide: a detached console app would otherwise flash its own console window on
+    // Windows. detached + unref so the child outlives this render's exit(0).
+    spawn(process.execPath, [__filename, 'update-check'], {
+      detached: true, stdio: 'ignore', windowsHide: true
+    }).unref();
+  } catch (e) {}
+}
+
+// The 'update-check' entry point: the detached child. Fetches the registry's latest
+// version, stamps the cache, exits. Writes nothing to stdout — it is not a statusline
+// mode, and its stdio is discarded by the parent anyway. A failed fetch leaves checkedAt
+// untouched, so the UPDATE_RETRY_MS backoff (not the weekly TTL) governs the next try.
+function runUpdateCheck() {
+  const done = (latest) => {
+    if (latest) writeUpdateCache({ ...(readUpdateCache() || {}), latest, checkedAt: Date.now() });
+    process.exit(0);
+  };
+
+  try {
+    const req = https.request({
+      hostname: REGISTRY_HOST,
+      path: `/${PACKAGE_NAME}/latest`,
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+      timeout: UPDATE_TIMEOUT_MS
+    }, (res) => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => done(parseRegistryVersion(body)));
+    });
+
+    req.on('error', () => done(null));
+    req.on('timeout', () => {
+      req.destroy();
+      done(null);
+    });
+
+    req.end();
+  } catch (e) {
+    done(null);
+  }
+}
+
 function getCredentials() {
   // Try file first (legacy / Linux / Windows)
   const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
@@ -669,11 +791,25 @@ function collectFacts(data) {
     const sync = branch ? formatAheadBehind(getGitAheadBehind(dir)) : '';
     const sessionId = data?.session_id || '';
     const task = DISABLED.has('task') ? '' : getCurrentTask(sessionId);
+    const update = DISABLED.has('update') ? '' : getLatestUpdate();
     const cols = parseInt(process.env.COLUMNS, 10);
-    return { dirname, branch, sync, task, cols };
+    return { dirname, branch, sync, task, update, cols };
   } catch (e) {
-    return { dirname: '~', branch: '', sync: '', task: '', cols: undefined };
+    return { dirname: '~', branch: '', sync: '', task: '', update: '', cols: undefined };
   }
+}
+
+// The update nudge gets its own row rather than a segment: Claude Code renders every
+// stdout line as a separate row, and the point of the nudge is the copy-pasteable command,
+// which is too wide to inline without forcing the main line to wrap on most terminals.
+// `npx <pkg>@latest` is the right command for script-installed users too — it recopies the
+// hook. Only the target version is shown — the running one is what you're looking at.
+function renderUpdateLine(latest) {
+  return `${colors.green}⬆${colors.reset} `
+    + `${colors.dim}update${colors.reset} `
+    + `${colors.green}${latest}${colors.reset} `
+    + `${colors.dim}· run:${colors.reset} `
+    + `${colors.bold}npx ${PACKAGE_NAME}@latest${colors.reset}`;
 }
 
 // Pure: data + facts (see collectFacts) + resolved usage bars -> the rendered line(s).
@@ -701,7 +837,8 @@ function renderStatusLine(data, facts, usage) {
   if (cost) line2.push(cost);
   if (facts.task) line2.push(`${colors.dim}${facts.task}${colors.reset}`);
 
-  return layout(line1, line2, facts.cols);
+  const body = layout(line1, line2, facts.cols);
+  return facts.update ? body + '\n' + renderUpdateLine(facts.update) : body;
 }
 
 // Main
@@ -714,7 +851,7 @@ function outputStatus(data, facts, usage) {
 }
 
 function outputFallback(usage) {
-  const facts = { dirname: '~', branch: '', sync: '', task: '', cols: undefined };
+  const facts = { dirname: '~', branch: '', sync: '', task: '', update: '', cols: undefined };
   process.stdout.write(renderStatusLine(null, facts, usage));
 }
 
@@ -774,6 +911,7 @@ function readStdinThen(timeoutMs, fn) {
 
 // Resolve usage for `data` (preferring stdin rate_limits), then render and exit.
 function emit(data) {
+  if (!DISABLED.has('update')) refreshUpdateCheck();
   resolveUsage(data, (usage) => {
     if (data) {
       outputStatus(data, collectFacts(data), usage);
@@ -854,10 +992,14 @@ function emitSubagent(data) {
 // directly (the /usage response shape is the easiest thing here to get wrong, and it
 // can't be reached through stdin). Running the script normally is unchanged.
 if (require.main === module) {
-  const isSubagent = process.argv[2] === 'subagent';
+  const mode = process.argv[2];
+  const isSubagent = mode === 'subagent';
   const finish = isSubagent ? emitSubagent : emit;
 
-  if (process.stdin.isTTY) {
+  if (mode === 'update-check') {
+    // Detached child spawned by refreshUpdateCheck: no stdin, no output, just the fetch.
+    runUpdateCheck();
+  } else if (process.stdin.isTTY) {
     finish(null);
   } else {
     const timeoutMs = isSubagent
@@ -866,5 +1008,5 @@ if (require.main === module) {
     readStdinThen(timeoutMs, (input) => finish(parseInput(input)));
   }
 } else {
-  module.exports = { parseScopedLimits, parseUsagePayload, serializeUsageCache, normalizePercentage, readStdinThen, renderStatusLine, renderSubagentTask };
+  module.exports = { parseScopedLimits, parseUsagePayload, serializeUsageCache, normalizePercentage, readStdinThen, renderStatusLine, renderSubagentTask, compareVersions, parseRegistryVersion };
 }

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -13,10 +13,23 @@ const { serializeUsageCache } = require('../statusline.js');
 const SCRIPT = path.join(__dirname, '..', 'statusline.js');
 
 // Fresh throwaway HOME with .claude/cache pre-created. Caller owns cleanup.
+// Seeds a latest-less update cache stamped now: `checkedAt` inside UPDATE_TTL_MS stops
+// refreshUpdateCheck spawning its registry child (tests stay offline), and no `latest`
+// means no update segment, so every other assertion is unaffected.
 function makeHome() {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-home-'));
   fs.mkdirSync(path.join(home, '.claude', 'cache'), { recursive: true });
+  seedUpdateCache(home, {});
   return home;
+}
+
+// Seed update-cache.json. `checkedAt` defaults to now (no registry child); pass a
+// `latest` to exercise the nudge, or an old `checkedAt`/`lastAttempt` for the TTL paths.
+function seedUpdateCache(home, { latest, checkedAt = Date.now(), lastAttempt } = {}) {
+  const entry = { checkedAt };
+  if (latest != null) entry.latest = latest;
+  if (lastAttempt != null) entry.lastAttempt = lastAttempt;
+  fs.writeFileSync(path.join(home, '.claude', 'cache', 'update-cache.json'), JSON.stringify(entry));
 }
 
 // Tokenless credentials file -- getApiUsage bails before any network/keychain call.
@@ -93,6 +106,6 @@ function spawnSubagent(input, env) {
 }
 
 module.exports = {
-  SCRIPT, makeHome, seedCredentials, seedUsageCache, seedFakeRepo,
+  SCRIPT, makeHome, seedCredentials, seedUsageCache, seedUpdateCache, seedFakeRepo,
   git, hasGit, gitCommit, seedDivergedRepo, spawnMain, spawnSubagent
 };

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -12,7 +12,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const {
-  makeHome, seedCredentials, seedUsageCache, seedFakeRepo,
+  makeHome, seedCredentials, seedUsageCache, seedUpdateCache, seedFakeRepo,
   git, hasGit, gitCommit, seedDivergedRepo: buildDivergedRepo, spawnMain, spawnSubagent
 } = require('./fixture.js');
 
@@ -139,6 +139,7 @@ const ORANGE = '\x1b[38;5;208m';
 const RED = '\x1b[31m';
 const PURPLE = '\x1b[38;5;135m';
 const DIM = '\x1b[2m';
+const BOLD = '\x1b[1m';
 const BLINK = '\x1b[5m';
 
 // renderStatusLine/renderSubagentTask are pure (no fs/child_process/network), so format,
@@ -146,7 +147,7 @@ const BLINK = '\x1b[5m';
 // child process. What's left spawned: git-branch/ahead-behind detection (real .git dir +
 // subprocess), the usage cache/API pipeline, CTXLINE_DISABLE env-parsing (module-load-time
 // state, needs a fresh process per value), and the execution-contract tests below.
-const { parseScopedLimits, parseUsagePayload, readStdinThen, renderStatusLine, renderSubagentTask } = require('../statusline.js');
+const { parseScopedLimits, parseUsagePayload, readStdinThen, renderStatusLine, renderSubagentTask, compareVersions, parseRegistryVersion } = require('../statusline.js');
 
 // Same shape as fixture()'s stdin JSON, but as a plain object (no JSON round-trip needed
 // for a direct call).
@@ -157,7 +158,7 @@ function dataObj(remaining, dir = '/tmp/myproject', model = 'Opus 4.8', effort, 
 // facts a git-free, task-free directory produces (what collectFacts returns absent any
 // repo/task/COLUMNS); override individual fields per test.
 function plainFacts(overrides = {}) {
-  return { dirname: 'myproject', branch: '', sync: '', task: '', cols: undefined, ...overrides };
+  return { dirname: 'myproject', branch: '', sync: '', task: '', update: '', cols: undefined, ...overrides };
 }
 
 function render(data, facts, usage) {
@@ -945,4 +946,72 @@ test('subagent: model-ID shortening strips a trailing build date - "claude-haiku
 test('subagent: model-ID shortening strips us./anthropic. vendor prefixes', () => {
   const content = renderSubagentTask({ id: 't', model: 'us.anthropic.claude-opus-5' });
   assert.strictEqual(cleanContent(content), 'agent │ Opus 5');
+});
+
+// --- update nudge ---------------------------------------------------------------
+
+test('compareVersions: orders releases, and refuses anything that is not x.y.z', () => {
+  assert.strictEqual(compareVersions('1.9.0', '1.6.2'), 1);
+  assert.strictEqual(compareVersions('1.6.2', '1.9.0'), -1);
+  assert.strictEqual(compareVersions('1.6.2', '1.6.2'), 0);
+  assert.strictEqual(compareVersions('1.10.0', '1.9.0'), 1);   // numeric, not lexical
+  assert.strictEqual(compareVersions('2.0.0-beta.1', '1.6.2'), null);
+  assert.strictEqual(compareVersions('1.6', '1.6.2'), null);
+  assert.strictEqual(compareVersions(undefined, '1.6.2'), null);
+});
+
+test('parseRegistryVersion: pulls version from a manifest, null on anything else', () => {
+  assert.strictEqual(parseRegistryVersion('{"name":"ctxline-claude","version":"1.9.0"}'), '1.9.0');
+  assert.strictEqual(parseRegistryVersion('{"version":"2.0.0-beta.1"}'), null);
+  assert.strictEqual(parseRegistryVersion('{"error":"Not found"}'), null);
+  assert.strictEqual(parseRegistryVersion('<html>502</html>'), null);
+  assert.strictEqual(parseRegistryVersion(''), null);
+});
+
+test('update nudge: own row below the statusline, main line untouched', () => {
+  const { raw, clean } = render(
+    dataObj(40, '/tmp/myproject', 'Opus 4.8', undefined, 0.42),
+    plainFacts({ update: '1.9.0', task: 'Refactoring' })
+  );
+  const rows = clean.split('\n');
+  assert.strictEqual(rows.length, 2, 'exactly one extra row');
+  // The nudge is appended, never mixed into the statusline's own segments.
+  assert.deepStrictEqual(rows[0].split(' │ ').slice(-2), ['$0.42', 'Refactoring']);
+  assert.strictEqual(rows[1], '⬆ update 1.9.0 · run: npx ctxline-claude@latest');
+  assert.ok(raw.includes(`${GREEN}⬆`), 'arrow is green');
+  assert.ok(raw.includes(`${GREEN}1.9.0`), 'new version is green');
+  assert.ok(raw.includes(`${BOLD}npx ctxline-claude@latest`), 'command is bold — the copy-paste target');
+});
+
+test('update nudge: absent when facts carry no update', () => {
+  const { clean } = render(dataObj(40), plainFacts());
+  assert.ok(!clean.includes('⬆'), 'no nudge row without a cached newer version');
+  assert.ok(!clean.includes('\n'), 'stays a single line');
+});
+
+test('update nudge: rides along with the responsive wrap as a third row', () => {
+  const { clean } = render(
+    dataObj(40, '/tmp/myproject', 'Opus 4.8', undefined, 0.42),
+    plainFacts({ update: '1.9.0', task: 'Refactoring', cols: 40 })
+  );
+  assert.strictEqual(clean.split('\n').length, 3);
+});
+
+test('update nudge: a newer cached version renders; an older one does not', () => {
+  const newer = freshHome();
+  seedUpdateCache(newer, { latest: '99.0.0' });
+  assert.match(run(fixture(40), { home: newer }).clean, /⬆ update 99\.0\.0 · run: npx ctxline-claude@latest/);
+
+  const older = freshHome();
+  seedUpdateCache(older, { latest: '0.0.1' });
+  assert.ok(!run(fixture(40), { home: older }).clean.includes('⬆'));
+});
+
+test('update nudge: CTXLINE_DISABLE=update hides it', () => {
+  const home = freshHome();
+  seedUpdateCache(home, { latest: '99.0.0' });
+  const { clean } = run(fixture(40), { home, disable: 'update' });
+  assert.ok(!clean.includes('⬆'), 'nudge suppressed');
+  assert.match(clean, /^myproject │ /, 'the rest of the line is untouched');
+  assert.ok(!clean.includes('\n'), 'no extra row');
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -977,9 +977,8 @@ test('update nudge: own row below the statusline, main line untouched', () => {
   assert.strictEqual(rows.length, 2, 'exactly one extra row');
   // The nudge is appended, never mixed into the statusline's own segments.
   assert.deepStrictEqual(rows[0].split(' │ ').slice(-2), ['$0.42', 'Refactoring']);
-  assert.strictEqual(rows[1], '⬆ update 1.9.0 · run: npx ctxline-claude@latest');
-  assert.ok(raw.includes(`${GREEN}⬆`), 'arrow is green');
-  assert.ok(raw.includes(`${GREEN}1.9.0`), 'new version is green');
+  assert.strictEqual(rows[1], '⬆ 1.9.0 available · npx ctxline-claude@latest');
+  assert.ok(raw.includes(`${GREEN}⬆ 1.9.0`), 'arrow and version are green');
   assert.ok(raw.includes(`${BOLD}npx ctxline-claude@latest`), 'command is bold — the copy-paste target');
 });
 
@@ -1000,7 +999,7 @@ test('update nudge: rides along with the responsive wrap as a third row', () => 
 test('update nudge: a newer cached version renders; an older one does not', () => {
   const newer = freshHome();
   seedUpdateCache(newer, { latest: '99.0.0' });
-  assert.match(run(fixture(40), { home: newer }).clean, /⬆ update 99\.0\.0 · run: npx ctxline-claude@latest/);
+  assert.match(run(fixture(40), { home: newer }).clean, /⬆ 99\.0\.0 available · npx ctxline-claude@latest/);
 
   const older = freshHome();
   seedUpdateCache(older, { latest: '0.0.1' });


### PR DESCRIPTION
## What

Adds an update nudge. When a newer `ctxline-claude` release is on npm, an extra row is appended below the statusline:

```
my-project ⎇ main │ Opus 4.8 (1M) · high │ C45 ███░░░ │ H14 ↺ 4h20m │ W31 ↺ 2d13h │ $44.21
⬆ 1.7.0 available · npx ctxline-claude@latest
```

Green `⬆ <version>`, dim `available ·`, bold command. `npx ctxline-claude@latest` is correct for `install.sh` / `install.ps1` users too — it recopies the hook — so one command covers every install path.

## How it stays off the render path

- **The render never fetches.** `collectFacts()` reads `~/.claude/cache/update-cache.json`; that's it.
- The refresh runs in a **detached** `node statusline.js update-check` child (`stdio: 'ignore'`, `windowsHide`, `.unref()`). Blocking inline would not have worked: the parent normally exits within ~50ms of stdin arriving, so it would have killed its own request nearly every time.
- `lastAttempt` is stamped **before** the spawn → offline machine, failed spawn, or killed child backs off 1h instead of respawning per render. A success stamps `checkedAt` → next check in 7 days. A failure leaves `checkedAt` alone, so the 1h backoff governs.
- A 7-day interval rather than a calendar-pinned Monday — same effect, no date math.
- The row is appended **after** `layout()`, so it never enters the wrap math. Narrow terminal → 3 rows, not a squeezed 2.
- `outputFallback()` is unchanged: still a single line, no nudge.

Measured render latency is unchanged.

## Version constant

`statusline.js` is copied standalone into `~/.claude/hooks/` with no `package.json` beside it, so the running version has to live in the file as `const VERSION`. This is the one ongoing cost of the feature: **`VERSION` must be bumped with `package.json` `version`.** Added a keep-in-sync row and a release-step note in `CLAUDE.md` so it isn't forgotten. Only used for the comparison — it isn't printed.

## Opt-out

`CTXLINE_DISABLE=update` skips the cache read and the spawn entirely.

## Testing

- 98/98 `npm test` pass; 6 new tests cover version comparison, registry-payload parsing, row placement/colors, the responsive third row, cache freshness, and the opt-out.
- `test/fixture.js`'s `makeHome()` now seeds a `latest`-less, freshly-stamped cache, so the suite never spawns the registry child — tests stay offline.
- Verified end-to-end against the real npm registry with a doctored local `VERSION`: cold render is clean, the child lands ~500ms later, next render shows the row.
- `npm run preview` has a new scenario for it.

## Notes

- Installers untouched — `update-check` is spawned internally by `statusline.js`, not a `settings.json` entry.
- `docs/index.html` hero mock and `preview.svg` left alone: the nudge is conditional and rare, so putting it in the marketing line would misrepresent the normal render. No drift; `test/docs-drift.test.js` still passes.
- `package.json` version not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a statusline notification when a newer release is available.
  * The notification includes a copy-and-paste upgrade command and is checked weekly in the background.
  * Update checks do not run during normal statusline rendering.

* **Configuration**
  * Added `update` to the `CTXLINE_DISABLE` options to hide the notification.

* **Documentation**
  * Added guidance and FAQ details covering update notifications and privacy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
