### PR TITLE
docs: slim CLAUDE.md and trim statusline.js comments (#48)

### DIFF
--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -35,6 +35,21 @@ dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 �
 - The `⬆` row is **not a segment**. `renderUpdateLine(latest)` builds it and `renderStatusLine` appends it after `layout()`, so it never affects wrap math. Green `⬆ <version>`, dim `available ·`, bold command. Conditional and rare — only when `update-cache.json` holds a `latest` strictly newer than `VERSION`. Cache-only on the render path; the fetch runs in the detached `update-check` entry point.
 - Consts: `BAR_WIDTH` 6 (bar cells), `SEGMENT_SEP` `' │ '`, `MAX_BRANCH_LEN` 24, `WIDTH_MARGIN` 0.
 
+### Segment sources
+
+| segment | source |
+|---|---|
+| dir | basename of stdin `workspace.current_dir` |
+| branch | `.git/HEAD` read directly, no subprocess (`resolveGitDir` walks up; worktree `.git` file + detached HEAD → short sha) |
+| `↑N↓M` | `getGitAheadBehind` — the only `git` subprocess, cache-fronted by `git-cache.json` |
+| model · effort | stdin `model.display_name` + `effort.level` |
+| `C` | stdin `context_window.remaining_percentage` (subagent rows: `tokenCount`/`contextWindowSize`) |
+| `H` / `W` | stdin `rate_limits` via `buildUsageFromStdin`, else the OAuth `/usage` API via `usage-cache.json` |
+| scoped weekly | `/usage` API only — never stdin |
+| `$` | stdin `cost.total_cost_usd`, no network/cache |
+| task | newest `~/.claude/todos/<sessionId>*-agent-*.json`, `activeForm` of the `in_progress` todo |
+| `⬆` row | `update-cache.json` only — the render path never fetches |
+
 ## Responsive wrap — reassign segments when order changes
 
 `layout(line1Parts, line2Parts, cols)` in `renderStatusLine` splits the line when visible width > `cols - WIDTH_MARGIN` (`cols` comes from `collectFacts`' read of `COLUMNS`; `layout` itself has no env access):

--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -16,7 +16,7 @@ description: Change the statusline's visible design — layout, segment format, 
 | `scripts/preview.js` | seed + render check | cache seed data (via `test/fixture.js`'s `seedUsageCache`), `render()` params (`columns`, `disable`); **primary `console.log` stays FIRST line** (release takes `head -n 1`) |
 | `docs/assets/preview.svg` | marketing SVG (README/site) | 2 of its 12 `<text>` elements (main statusline + subagent row) are **generated**, not hand-edited — run `npm run preview:svg` after any output-shape change; the other 10 (window chrome, prompt lines, bullets) stay hand-authored |
 | `docs/index.html` | landing page | hero mock (`.term .line`) and subagent rows are checked by `test/docs-drift.test.js` (fails `npm test` on drift) — update its synthetic scenario if you change what they depict; inspector `SIGNALS[]` array and `.term` color classes are NOT checked, hand-verify |
-| `CLAUDE.md` | spec | format diagram (top), segment-source table, "visible contract" paragraph |
+| `CLAUDE.md` | spec | format diagram + segment legend (top) |
 
 After edits: `npm test` + `npm run preview` + `npm run preview:svg`. All must pass + look right.
 

--- a/.claude/skills/restyle-statusline/SKILL.md
+++ b/.claude/skills/restyle-statusline/SKILL.md
@@ -11,12 +11,12 @@ description: Change the statusline's visible design — layout, segment format, 
 
 | File | What to change | Where |
 |---|---|---|
-| `statusline.js` | render logic — source of truth | `getContextBar`, `buildUsageBar`, `buildUsageBars`, `formatAheadBehind`, `getCostSegment`, `getLatestUpdate`, `renderUpdateLine`, `layout`, `collectFacts`, `renderStatusLine`, `outputStatus`, `outputFallback` |
+| `statusline.js` | render logic — source of truth | `renderContextBar`, `getContextBar`, `renderSubagentTask`, `buildUsageBar`, `buildUsageBars`, `formatAheadBehind`, `getCostSegment`, `getLatestUpdate`, `renderUpdateLine`, `layout`, `collectFacts`, `renderStatusLine`, `outputStatus`, `outputFallback` |
 | `test/render.test.js` | assertions on labels / `NN%` / colors / order | match new label regexes (e.g. `/C\d+ /`, `/H\d+\b/`); ANSI const block near top |
 | `scripts/preview.js` | seed + render check | cache seed data (via `test/fixture.js`'s `seedUsageCache`), `render()` params (`columns`, `disable`); **primary `console.log` stays FIRST line** (release takes `head -n 1`) |
 | `docs/assets/preview.svg` | marketing SVG (README/site) | 2 of its 12 `<text>` elements (main statusline + subagent row) are **generated**, not hand-edited — run `npm run preview:svg` after any output-shape change; the other 10 (window chrome, prompt lines, bullets) stay hand-authored |
 | `docs/index.html` | landing page | hero mock (`.term .line`) and subagent rows are checked by `test/docs-drift.test.js` (fails `npm test` on drift) — update its synthetic scenario if you change what they depict; inspector `SIGNALS[]` array and `.term` color classes are NOT checked, hand-verify |
-| `CLAUDE.md` | spec | format diagram + segment legend (top) |
+| `CLAUDE.md` | spec | format diagram + segment legend (top); its Invariants block also hard-codes the timing/TTL numbers, stdin field list, and `module.exports` list |
 
 After edits: `npm test` + `npm run preview` + `npm run preview:svg`. All must pass + look right.
 
@@ -29,7 +29,7 @@ dir ⎇ branch ↑N↓M │ model · effort │ C45 ███░░░ │ H14 �
 
 - Labels fused with percent: `C`=context, `H`=5h, `W`=7d, `<initial>`=model-scoped weekly limit (Fable → `F`, label derived from `scope.model.display_name` in `parseScopedLimits` — never hardcode a model list).
 - Context keeps a bar; `H`/`W`/scoped are label + `↺ countdown`, no bar.
-- Labels live INSIDE the builder functions (`getContextBar`/`buildUsageBar`), not as prefixes in `renderStatusLine`. `renderStatusLine` pushes segments verbatim; `outputStatus`/`outputFallback` are thin writers that call it.
+- Labels live INSIDE the builder functions (`renderContextBar`/`buildUsageBar`), not as prefixes in `renderStatusLine`. `renderStatusLine` pushes segments verbatim; `outputStatus`/`outputFallback` are thin writers that call it.
 - `↑N↓M` is appended to the branch string (↑ green / ↓ red), not a separate segment. Zero side omitted.
 - `$<cost>` is dim, sits after usage and before task.
 - The `⬆` row is **not a segment**. `renderUpdateLine(latest)` builds it and `renderStatusLine` appends it after `layout()`, so it never affects wrap math. Green `⬆ <version>`, dim `available ·`, bold command. Conditional and rare — only when `update-cache.json` holds a `latest` strictly newer than `VERSION`. Cache-only on the render path; the fetch runs in the detached `update-check` entry point.
@@ -70,9 +70,11 @@ Adding or moving a segment means picking its line in `renderStatusLine`, not jus
 
 | | Thresholds |
 |---|---|
-| context (`getContextBar`) | green <50 / yellow <65 / orange <80 / **blink-red** ≥80 |
+| context (`renderContextBar`) | green <50 / yellow <65 / orange <80 / **blink-red** ≥80 |
 | usage `H`/`W` (`getUsageColor`) | green <50 / yellow <75 / orange <90 / red ≥90 |
 | model-scoped bars (`getScopedColor`) | orange < 90 / red ≥90 — passed as `buildUsageBar`'s optional 4th arg |
+
+Context bands live in `renderContextBar`, not `getContextBar` — the latter only clamps remaining→used and delegates. `renderSubagentTask` calls the same function, so changing the bands recolors every subagent row too.
 
 Scoped bars are deliberately flat so a line carrying `H W O F` reads as two groups, not four severities; red ≥90 is the one exception, for a cap about to block its model. Restoring full threshold color means dropping that 4th arg — and updating the two scoped-color tests.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,18 +9,17 @@ dir ⎇ branch ↑N↓M │ model · effort │ C<used> <bar> │ H<pct> ↺ <re
 ⬆ <latest> available · npx ctxline-claude@latest
 ```
 
-`C` context (only segment with a bar), `H` 5-hour usage, `W` 7-day usage, `<model-initial>` model-scoped weekly limit (Fable → `F`), `$` session cost. Everything after `dir`/`model`/`C` is conditional — renders only when its source resolves. The `⬆` row is **not a segment** — it's appended below whatever the layout produced, only when a newer release is cached.
+`C` context (only segment with a bar), `H` 5-hour usage, `W` 7-day usage, `<model-initial>` model-scoped weekly limit, `$` session cost. Everything after `dir`/`model`/`C` is conditional — renders only when its source resolves. The `⬆` row is not a segment — appended below the layout only when a newer release is cached.
 
 ## Commands
 
 No build, no lint. Edit `statusline.js` directly.
 
 ```bash
-npm test           # render tests (Node built-in runner, zero deps)
-npm run preview    # sample lines for every color band + fallback
+npm test            # render tests (Node built-in runner, zero deps)
+npm run preview     # sample lines for every color band + fallback
 npm run preview:svg # regenerate docs/assets/preview.svg's statusline tspans from a real render
-npm pack --dry-run # preview what publishes
-# Never publish by hand — see Distribution + releasing.
+npm pack --dry-run  # preview what publishes
 
 # Main line — the stdin JSON Claude Code sends:
 echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp/x"},"session_id":"t","context_window":{"remaining_percentage":40}}' | node statusline.js
@@ -28,119 +27,62 @@ echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp/x"},
 # Update check (detached child; writes ~/.claude/cache/update-cache.json, prints nothing):
 node statusline.js update-check
 
-# Subagent rows (startTime = 4m12s ago, epoch seconds — format note below):
+# Subagent rows:
 echo '{"tasks":[{"id":"t1","name":"reviewer","model":"claude-opus-5","effort":"max","tokenCount":45200,"contextWindowSize":200000,"startTime":'$(($(date +%s)-252))'}]}' | node statusline.js subagent
 ```
 
-Publishing + local-install detail: `docs/DEV.md`.
+Never publish by hand — see Distribution + releasing. Publishing + local-install detail: `docs/DEV.md`.
 
 ## Architecture
 
-`statusline.js` is the entire product — standalone, zero-dependency Node (built-ins only). Installers copy it to `~/.claude/hooks/`: no non-builtin `require()`s, no module split, no assuming sibling files exist at runtime.
+`statusline.js` is the entire product — standalone, zero-dependency Node (built-ins only). Installers copy it alone to `~/.claude/hooks/`: no non-builtin `require()`s, no module split, no sibling files at runtime.
 
-**Execution contract.** Claude Code pipes session JSON via stdin every render, reads stdout (one or two lines). Must **always** print, **never** hang/throw — every path falls back to cached/partial/`outputFallback()`, failures swallow silently.
+**Execution contract.** Claude Code pipes session JSON via stdin every render, reads stdout (one or two lines). Always print, never hang/throw — every path falls back to cached/partial/`outputFallback()`; failures swallow silently. Timing is load-bearing: stdin raced against `overallTimeout` (500ms with `ANTHROPIC_API_KEY`, else 1300/1600ms by cache presence); first to fire prints and `exit(0)`.
 
-Reads from stdin: `model.display_name`, `workspace.current_dir`, `session_id`, `effort.level`, `context_window.remaining_percentage`, `cost.total_cost_usd` (USD float), `rate_limits` (`five_hour`/`seven_day`, each `{ used_percentage, resets_at }` — `resets_at` is Unix epoch **seconds**). Env: `COLUMNS` (terminal width, set by Claude Code v2.1.153+), `CTXLINE_DISABLE`.
+**stdin:** `model.display_name`, `workspace.current_dir`, `session_id`, `effort.level`, `context_window.remaining_percentage`, `cost.total_cost_usd`, `rate_limits.five_hour/seven_day` (`{ used_percentage, resets_at }` — `resets_at` is Unix epoch **seconds**). Env: `COLUMNS` (set by Claude Code v2.1.153+), `CTXLINE_DISABLE` (opt-out: `branch`, `effort`, `cost`, `task`, `update`, `usage`; `dir`/`model`/`context` always render; disabling skips the work, not just the output).
 
-**Timing is load-bearing.** stdin raced against `overallTimeout` (500ms with `ANTHROPIC_API_KEY`, else 1300/1600ms by cache presence); first to fire prints and `exit(0)`. Usage API has its own timeout (1200ms warm / 1500ms cold) and fires only on the fallback path.
+**Invariants:**
+- Render path never touches the network: usage comes from stdin or `~/.claude/cache/`; the update check runs in a detached child with `lastAttempt` stamped before the spawn (failures back off 1h, successes 7d).
+- Model-scoped weekly bars exist only in the OAuth `/usage` payload — never in stdin.
+- `collectFacts()` owns fs/child_process/env access; `renderStatusLine()` is pure. Both exported under `require.main === module` for direct test use.
+- Caches (`~/.claude/cache/`): `usage-cache.json` fresh 30s / stale-fallback 10m, `lastAttempt` cooldown applies to failed attempts too; `git-cache.json` 5s/60s; `update-cache.json` read-only on the render path.
 
-**Segment opt-out.** `CTXLINE_DISABLE` comma list parsed once into `DISABLED` (trimmed, lowercased). Recognized: `branch`, `effort`, `cost`, `task`, `update`, `usage` (H+W). `dir`/`model`/`context` always render; unknown names ignored. Disabling skips the work, not just the output — `usage` means no network/cache/credentials at all.
+Segment sources, color thresholds, layout/wrap rules, full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.
 
-**Responsive layout (`layout()`).** Visible width (ANSI stripped) > `COLUMNS - WIDTH_MARGIN` → two lines: line 1 dir/branch + model/effort + `C`; line 2 `H`/`W` + `$` + task. Fires only when `COLUMNS` is a known positive int and line 2 is non-empty — unknown width, wide terminal, or nothing to wrap stays single-line, as does `outputFallback()`. `cols` is a parameter, never an env read, so `layout()`/`renderStatusLine()` have no side effects.
+## Subagent mode
 
-**Segment sources + gotchas** (each best-effort):
-
-| segment | source | gotchas |
-|---|---|---|
-| dir + branch | basename of `current_dir`; branch straight from `.git/HEAD`, no subprocess | `resolveGitDir()` walks up; handles worktree (`.git` file) + detached HEAD (short sha); tail-truncated to `MAX_BRANCH_LEN` 24 (keeps leading ticket ID); `''` on failure |
-| `↑N↓M` | `getGitAheadBehind(dir)` — the only `git` subprocess (`execFileSync`, `rev-list --left-right --count @{u}...HEAD`) | no shell (faster cold spawn, `@{u}` passed literally); output is `"<behind>\t<ahead>"`; `GIT_TIMEOUT_MS` 500ms; cache-fronted; omitted on `null`, in sync, no upstream, detached; a zero side is dropped |
-| model · effort | stdin | `(1M context)` → `(1M)`; effort ranks low<medium<high<xhigh<max<ultracode, only `max` (red) + `ultracode` (purple) highlighted, rest dim |
-| `C` | stdin `remaining_percentage` | always available |
-| `$` | stdin `cost.total_cost_usd`, no network/cache | `Number.isFinite`-guarded; client-side estimate at API pricing — for subscription users, not actual billing |
-| `H` / `W` | stdin `rate_limits` via `buildUsageFromStdin()`, else `getRawUsage()` → OAuth API | `rate_limits` exists only for Claude.ai Pro/Max **after the first API response** — absent at cold start and for API-key users, hence the fallback |
-| scoped weekly | OAuth API only | never arrives via stdin; `getScopedColor` (orange, red ≥90), not the H/W thresholds |
-| `⬆` row | `update-cache.json` only — never the network on the render path | `getLatestUpdate()` compares the cached `latest` against `VERSION`; `''` unless strictly newer, and both sides must be strict `x.y.z` (a prerelease never nudges). `renderUpdateLine()` appends it *after* `layout()`, so it never competes for width and never joins the wrap decision |
-| task | newest `~/.claude/todos/<sessionId>*-agent-*.json` | `activeForm` of the `in_progress` todo |
-
-**Usage API.** `GET api.anthropic.com/api/oauth/usage`, bearer token + `anthropic-beta: oauth-2025-04-20`. Token from `getCredentials()`: `~/.claude/.credentials.json`, then macOS keychain. API-key users get no usage.
-- Both adapters return `{ fiveHour, weekly, models }` → `buildUsageBars(raw)`, one positional object. `buildUsageFromStdin()`'s `models` is always `[]` (stdin never carries scoped limits).
-- `parseUsagePayload(body)` — pure, no fs/network; `null` on unparseable JSON or a missing/non-finite `five_hour` utilization. `getApiUsage()` calls it and owns only credentials/socket/timeout/cache-write.
-- `getRawUsage()` is cache-first, and checks the `lastAttempt` cooldown (`getLastAttemptAge()`, `FRESH_TTL_MS`) before calling `getApiUsage()` at all → a failed/timed-out refresh backs off the same as a successful one.
-- `parseScopedLimits(usage)` reads `limits[]` for `kind: 'weekly_scoped'`; label = first initial of `scope.model.display_name` (new model family needs no code change). Legacy flat `seven_day_opus`/`seven_day_sonnet` only when `limits` yields nothing → neither shape double-counts.
-- `resolveUsage()` still calls `getRawUsage()` for the scoped bars when `H`/`W` came from stdin. Capped at one call per `FRESH_TTL_MS`; a slow/failed call costs only those bars.
-
-**Update check.** `GET registry.npmjs.org/ctxline-claude/latest` → `parseRegistryVersion(body)` (pure; `null` on anything but strict `x.y.z`). Anonymous — no credentials, no session data.
-- Rendered as its **own stdout row** (Claude Code renders each line as a separate row), not a segment: the copy-pasteable `npx ctxline-claude@latest` is too wide to inline without forcing the main line to wrap on most terminals. `npx <pkg>@latest` is correct for `install.sh`/`install.ps1` users too — it recopies the hook.
-- **Render never fetches.** `emit()` calls `refreshUpdateCheck()` → spawns a **detached** `node statusline.js update-check` child (`stdio: 'ignore'`, `.unref()`), returns immediately. Parent exits on its usual stdin race; child writes the cache ~300ms later, so the nudge shows on the next render. Blocking inline would break the timing contract for a segment nobody waits on.
-- `lastAttempt` stamped **before** the spawn → offline machine / failed spawn / killed child backs off `UPDATE_RETRY_MS` (1h) instead of respawning per render. Success stamps `checkedAt` → next check gated by `UPDATE_TTL_MS` (7 days). Failure leaves `checkedAt` untouched, so the 1h backoff governs, not the weekly one.
-- Interval, not calendar-pinned. "7 days since last success" needs no date math; drift is harmless.
-- `VERSION` constant lives in `statusline.js`: installers copy that file alone into `~/.claude/hooks/`, no `package.json` beside it at runtime. **Bump it with `package.json`** — see keep-in-sync below.
-- `CTXLINE_DISABLE=update` skips cache read and spawn entirely.
-
-**Render seam.** `collectFacts(data)` gathers everything touching fs/child_process/env (git branch + ahead/behind, in-progress task, cached update version, `COLUMNS`); pure `renderStatusLine(data, facts, usage)` formats; `outputStatus` is a ~3-line writer, try/catch → `Status unavailable`. `outputFallback` calls the same renderer with a static git/task-free `facts` (`cols: undefined` → single line, matching the fallback contract). Entry guarded by `require.main === module` so `test/render.test.js` can `require()` and call exports directly instead of spawning: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`, `compareVersions`, `parseRegistryVersion`, `VERSION`.
-
-**Caches** (all in `~/.claude/cache/`):
-- `usage-cache.json` — `{ timestamp, data: { fiveHour, weekly, models }, lastAttempt }`, not formatted strings → old string-format caches ignored on read. Shared across sessions; `models` optional (pre-scoped-bars caches still validate). Fresh `FRESH_TTL_MS` 30s → render cache, skip API; stale → refresh, on API failure fall back to cache up to `STALE_TTL_MS` 10m. `lastAttempt` — stamped by `recordUsageAttempt()` before the request fires, success or failure — is the retry cooldown, independent of `timestamp`. Segments re-rendered every time via `buildUsageBar()` so countdowns recompute from `resetsAt`. Fronts the API path only — stdin `rate_limits` never reads or writes it.
-- `update-cache.json` — `{ latest, checkedAt, lastAttempt }`, all optional. Written by the detached `update-check` child (`latest` + `checkedAt`) and by `refreshUpdateCheck()` (`lastAttempt` only). Read-only on the render path. Shared across sessions like the others.
-- `git-cache.json` — single entry `{ gitDir, timestamp, ahead, behind }`; different repo invalidates. Fresh `GIT_FRESH_TTL_MS` 5s (render burst spawns `git` once) → stale re-run → on slow/failed call fall back to last counts up to `GIT_STALE_TTL_MS` 60s so they don't flicker.
-
-**Two color schemes (intentional, do not unify):** context bar (`getContextBar`) steps 50/65/80 (≥80 → blink red); usage (`getUsageColor`) steps 50/75/90. Model-scoped bars opt out of both — `getScopedColor` (orange, red ≥90) passed as `buildUsageBar`'s optional 4th arg → several scoped bars read as one group while a nearly-spent one still stands out.
-
-**Deliberate non-goals — do not re-propose:**
-- **Merging the two caches, or the two duration formatters** (`buildUsageBar`'s countdown vs `formatElapsed`). Two callers each, differing validators / units / refresh policies (git 5s/60s vs usage 30s/10m; countdown vs elapsed) — a shared `withCache`/`formatDuration` moves complexity into parameters. Revisit only on a third caller.
-- **Making the `lastAttempt` cooldown atomic.** The check (`getLastAttemptAge()`) and the claim (`recordUsageAttempt()`) aren't atomic across processes — every render that reads a stale `lastAttempt` before any of them writes one calls `getApiUsage()`, so the extra calls scale with how many hook processes render at once (the cache is shared across sessions), not a fixed one. Still never a crash or bad render; a filesystem lock plus a multi-process test contradicts the single-file, zero-dependency constraint. Revisit only if concurrent hook processes prove common.
-
-## Subagent mode (`subagentStatusLine`)
-
-Second entry point in the same file, activated by `process.argv[2] === 'subagent'` — one row per running subagent task in the agent panel, wired in `settings.json` as a separate command from `statusLine`:
-
-```json
-{ "subagentStatusLine": { "type": "command", "command": "node ~/.claude/hooks/statusline.js subagent" } }
-```
-
-- Stdin: `{ tasks: [...], ... }` (base fields `session_id`/`cwd`/`columns` present but unused). Each task: `id`, `name`/`description`/`label`, `type`, `status`, `startTime`, `model` (resolved ID, absent until resolved), `effort` (level string or numeric token budget, absent when the subagent inherits session effort), `contextWindowSize`, `tokenCount`, `tokenSamples`, `cwd`.
-- Stdout: one `{"id","content"}` JSON line per task to override. Omitted id → default rendering; empty `content` → row hidden.
-
-Row: `name │ Model · effort │ C<used> <bar> │ ⏱ <elapsed>`, built by `renderSubagentTask()`. Reuses main-line blocks rather than duplicating: `SEGMENT_SEP`, `renderContextBar()` (used%→bar/color, factored out of `getContextBar`, shared by both), `getEffortColor()`. `shortenModelId()` shortens the resolved model *ID* ("claude-opus-5" → "Opus 5"; strips `us.`/`anthropic.` prefixes and a trailing `-YYYYMMDD` date) — distinct from `shortenModel()`, which only trims `" context)"` off a display *name*.
-
-Every segment past `name` is independently conditional: no `model` → no model/effort segment (effort alone still renders); no `effort` → no `· effort` suffix; `tokenCount`/`contextWindowSize` not both finite (or window ≤ 0) → no context bar; unparseable `startTime` → no elapsed segment.
-
-`startTime`'s format isn't documented upstream and isn't otherwise read in this file, so `formatElapsed()` accepts whatever shows up: number < `1e12` → epoch-seconds, larger → epoch-ms, anything else handed straight to `Date()` (covers an ISO string). Revisit if a real payload contradicts this.
-
-Skips everything main mode does besides stdin parsing — no usage API, git, todos, cache — so no `overallTimeout` race against a fetch; `emitSubagent()` hard-caps the stdin read at `SUBAGENT_TIMEOUT_MS`. Bad/missing payload, or a task whose shape breaks rendering → emit nothing rather than a partial line: default rendering stays for every task in the panel, process still exits 0.
+`node statusline.js subagent` — one `{"id","content"}` JSON row per running task in the agent panel. Reads only stdin (capped at `SUBAGENT_TIMEOUT_MS`); bad payload → emit nothing, exit 0. Row `name │ Model · effort │ C<used> <bar> │ ⏱ <elapsed>`; every segment past `name` is independently conditional.
 
 ## Keep in sync when `statusline.js` changes
 
-`statusline.js` is source of truth; the six files below mirror it and must change in the same edit or CI/release/site drifts. Author edits `statusline.js`; assistant re-syncs. After any edit run `npm test` + `npm run preview`.
+`statusline.js` is source of truth; these files mirror it — change in the same edit or CI/release/site drifts. After any edit run `npm test` + `npm run preview`.
 
 | file | mirrors | trap |
 |---|---|---|
-| `scripts/preview.js` | cache seed passed to `seedUsageCache`, `render()` params/labels, stdin input object | release body shows `head -n 1` → keep the primary-line `console.log` **first**; a stale seed makes usage render wrong or vanish |
-| `test/render.test.js` | visible labels / percentages / colors / order | ANSI `colors` constants sit atop the file — update them when codes change |
-| `docs/assets/preview.svg` | the statusline `<text>` elements' `<tspan>` runs (README + site) | generated, never hand-edited — run `npm run preview:svg` after anything that shifts this scenario's output; window chrome, prompt lines, and the "○ " bullet stay hand-authored |
-| `docs/index.html` | hero mock (`.term .line`) + subagent-panel rows | byte-compared against real `renderStatusLine()`/`renderSubagentTask()` calls by `test/docs-drift.test.js`, so drift fails `npm test`; inspector `SIGNALS[]` and `.term` color classes are unchecked — hand-verify |
-| `CLAUDE.md` | format diagram (top), segment-source table, visible contract below | — |
-| `package.json` | `version` ↔ the `VERSION` constant in `statusline.js` | not a visible-line mirror, but the same class of drift: a stale `VERSION` makes every installed copy nudge for an update forever (or never). Enforced — `npm test` asserts the two match, so a half-bump fails locally and blocks the release workflow |
+| `scripts/preview.js` | cache seed, `render()` params, stdin input | release body shows `head -n 1` → primary-line `console.log` stays **first** |
+| `test/render.test.js` | visible labels / percentages / colors / order | ANSI `colors` constants atop the file |
+| `docs/assets/preview.svg` | statusline `<tspan>` runs (README + site) | generated — run `npm run preview:svg`, never hand-edit |
+| `docs/index.html` | hero mock + subagent rows | byte-compared by `test/docs-drift.test.js` → drift fails `npm test` |
+| `CLAUDE.md` | format diagram + segment legend (top) | — |
+| `package.json` | `version` ↔ the `VERSION` constant | test-enforced; a stale `VERSION` nudges forever (or never) |
 
-`test/fixture.js` is the shared harness behind test + preview, not one of the six: fake-HOME construction, `usage-cache.json` seeding (via the exported `serializeUsageCache`, so the on-disk shape can't drift between writer and seed), `update-cache.json` seeding (`makeHome()` stamps a `latest`-less one so tests never spawn the registry child), diverged-repo building, spawn wrappers for both entry points. Dev-only, outside the `files` whitelist.
+Triggers: visible output change → test assertions + `npm run preview:svg`; cache shape or stdin fields → both seeds; version bump → `VERSION` in `statusline.js` too.
 
-Triggers: change to **what the line looks like** → test assertions (+ `npm run preview:svg`). Change to **cache shape or stdin fields** → both seeds. Version bump → `VERSION` in `statusline.js` too. `npm run preview` is the fast visual check. (README has no sample line — leave it.)
+`test/fixture.js` backs test + preview (fake HOME, cache seeds, spawn wrappers). Harness options: `SKILL.md`.
 
-Full edit-point map, test-harness options, and the ANSI/SVG color tables: `.claude/skills/restyle-statusline/SKILL.md`.
+## Non-goals — do not re-propose
 
-Visible contract = format diagram (top) + color steps above, plus: only `C` gets a bar glyph (`buildUsageBar` builds text-only `H`/`W`/scoped segments despite the name); `$<cost>` dim, after usage and before task; `↑N↓M` ↑ green / ↓ red; the `⬆` row appended below the layout (green `⬆ <version>`, dim `available ·`, bold command), never inside it; responsive wrap (narrow → line 2 = `H`/`W`/`$`/task); always-print-and-exit-0 fallback.
+- Merging the two caches, or the two duration formatters (usage countdown vs subagent elapsed): two callers each, differing validators/units/TTLs. Revisit on a third caller.
+- Atomic `lastAttempt` cooldown: check+claim aren't cross-process atomic; worst case is a few extra API calls, never a bad render. A file lock + multi-process test contradicts single-file/zero-dep.
 
 ## Do not touch the installers
 
-Work in `statusline.js` only. Install path is frozen (inherited working from upstream):
-- No behavior change to `bin/install.js`, `install.sh`, `install.ps1` except unavoidable branding (repo URL / package name) or wiring a settings.json entry a shipped `statusline.js` feature already depends on (e.g. `subagentStatusLine`).
-- `npx ctxline-claude` → `bin/install.js` installs silently, no prompts. Keep it so.
-- All three write both `statusLine` and `subagentStatusLine` → same hook file (`subagentStatusLine` appends a space + `subagent`), path written quoted (the command runs through a shell, so an unquoted home dir with spaces splits into two args). New entry point → wire into all three, not just document the snippet.
-- Uninstall: `npx ctxline-claude uninstall` (arg `uninstall`/`remove`) — removes only our two keys (guarded, backed up), deletes the hook, clears the cache. Additive; must not alter the no-arg install. `install.sh`/`install.ps1` have no uninstall command, only printed manual-removal instructions — which must list both keys too.
-- No "Full vs Lite" prompt or `statusline-lite.js` (deleted upstream `846e10e`) unless reintroduced as a deliberate real feature.
+Install path frozen. No behavior change to `bin/install.js`, `install.sh`, `install.ps1` except branding (repo URL / package name) or wiring a settings.json entry a shipped feature already depends on. `npx ctxline-claude` installs silently. All three write both `statusLine` and `subagentStatusLine` to the same hook file (path written quoted). New entry point → wire into all three.
+
+Uninstall: `npx ctxline-claude uninstall` removes only our two keys (guarded, backed up), deletes the hook, clears the cache. `install.sh`/`install.ps1` have no uninstall command — their printed manual-removal instructions must list both keys. No Full/Lite prompt or second statusline file.
 
 ## Distribution + releasing
 
-`statusline.js` is fetched verbatim from GitHub `main` by `install.sh`/`install.ps1` (via `REPO_URL`) and copied by `bin/install.js`. A change on `main` ships to anyone re-running the installers — keep `main` releasable. `package.json` `files` whitelists what publishes.
+`statusline.js` is fetched verbatim from GitHub `main` by `install.sh`/`install.ps1` and copied by `bin/install.js` — a change on `main` ships to anyone re-running the installers; keep `main` releasable. `package.json` `files` whitelists what publishes.
 
-Releases are owner-triggered, manual: bump `version` in `package.json` **and the `VERSION` constant in `statusline.js`** on `main` (a test asserts they match), then run the **Release** workflow (`.github/workflows/release.yml`), which publishes from that version. Never `npm publish` by hand; never bump the version unasked.
+Releases are owner-triggered, manual: bump `version` in `package.json` **and the `VERSION` constant in `statusline.js`** on `main` (a test asserts they match), then run the **Release** workflow (`.github/workflows/release.yml`). Never `npm publish` by hand; never bump the version unasked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Never publish by hand — see Distribution + releasing. Publishing + local-insta
 **Invariants:**
 - Render path never touches the network: usage comes from stdin or `~/.claude/cache/`; the update check runs in a detached child with `lastAttempt` stamped before the spawn (failures back off 1h, successes 7d).
 - Model-scoped weekly bars exist only in the OAuth `/usage` payload — never in stdin.
-- `collectFacts()` owns fs/child_process/env access; `renderStatusLine()` is pure. Both exported under `require.main === module` for direct test use.
+- `collectFacts()` owns fs/child_process/env access; `renderStatusLine()` is pure. Exported under `require.main === module` for direct test use: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`, `compareVersions`, `parseRegistryVersion`, `VERSION` (not `collectFacts` — it's the impure half).
 - Caches (`~/.claude/cache/`): `usage-cache.json` fresh 30s / stale-fallback 10m, `lastAttempt` cooldown applies to failed attempts too; `git-cache.json` 5s/60s; `update-cache.json` read-only on the render path.
 
 Segment sources, color thresholds, layout/wrap rules, full edit-point map: `.claude/skills/restyle-statusline/SKILL.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ node statusline.js update-check
 echo '{"tasks":[{"id":"t1","name":"reviewer","model":"claude-opus-5","effort":"max","tokenCount":45200,"contextWindowSize":200000,"startTime":'$(($(date +%s)-252))'}]}' | node statusline.js subagent
 ```
 
-Never publish by hand — see Distribution + releasing. Publishing + local-install detail: `docs/DEV.md`.
+Live-test the working tree without installing: `.claude/skills/local-statusline-test/SKILL.md`.
 
 ## Architecture
 
@@ -42,7 +42,7 @@ Never publish by hand — see Distribution + releasing. Publishing + local-insta
 **stdin:** `model.display_name`, `workspace.current_dir`, `session_id`, `effort.level`, `context_window.remaining_percentage`, `cost.total_cost_usd`, `rate_limits.five_hour/seven_day` (`{ used_percentage, resets_at }` — `resets_at` is Unix epoch **seconds**). Env: `COLUMNS` (set by Claude Code v2.1.153+), `CTXLINE_DISABLE` (opt-out: `branch`, `effort`, `cost`, `task`, `update`, `usage`; `dir`/`model`/`context` always render; disabling skips the work, not just the output).
 
 **Invariants:**
-- Render path never touches the network: usage comes from stdin or `~/.claude/cache/`; the update check runs in a detached child with `lastAttempt` stamped before the spawn (failures back off 1h, successes 7d).
+- Usage is cache-first: stdin `rate_limits` or `~/.claude/cache/`, refreshed from the OAuth `/usage` API on the render path only when the cache is past `FRESH_TTL_MS` and no `lastAttempt` cooldown applies (own timeout, 1200ms warm / 1500ms cold). The update check is the one thing that never runs on the render path — detached child, `lastAttempt` stamped before the spawn (failures back off 1h, successes 7d).
 - Model-scoped weekly bars exist only in the OAuth `/usage` payload — never in stdin.
 - `collectFacts()` owns fs/child_process/env access; `renderStatusLine()` is pure. Exported under `require.main === module` for direct test use: `renderStatusLine`, `renderSubagentTask`, `parseScopedLimits`, `parseUsagePayload`, `normalizePercentage`, `readStdinThen`, `serializeUsageCache`, `compareVersions`, `parseRegistryVersion`, `VERSION` (not `collectFacts` — it's the impure half).
 - Caches (`~/.claude/cache/`): `usage-cache.json` fresh 30s / stale-fallback 10m, `lastAttempt` cooldown applies to failed attempts too; `git-cache.json` 5s/60s; `update-cache.json` read-only on the render path.
@@ -63,10 +63,10 @@ Segment sources, color thresholds, layout/wrap rules, full edit-point map: `.cla
 | `test/render.test.js` | visible labels / percentages / colors / order | ANSI `colors` constants atop the file |
 | `docs/assets/preview.svg` | statusline `<tspan>` runs (README + site) | generated — run `npm run preview:svg`, never hand-edit |
 | `docs/index.html` | hero mock + subagent rows | byte-compared by `test/docs-drift.test.js` → drift fails `npm test` |
-| `CLAUDE.md` | format diagram + segment legend (top) | — |
+| `CLAUDE.md` | format diagram + legend (top), timing/TTL numbers, stdin fields, export list | the Invariants block hard-codes constants — grep it for any number you change |
 | `package.json` | `version` ↔ the `VERSION` constant | test-enforced; a stale `VERSION` nudges forever (or never) |
 
-Triggers: visible output change → test assertions + `npm run preview:svg`; cache shape or stdin fields → both seeds; version bump → `VERSION` in `statusline.js` too.
+Triggers: visible output change → test assertions + `npm run preview:svg`; cache shape or stdin fields → both seeds; timing/TTL constants or `module.exports` → the Invariants block above; version bump → `VERSION` in `statusline.js` too.
 
 `test/fixture.js` backs test + preview (fake HOME, cache seeds, spawn wrappers). Harness options: `SKILL.md`.
 
@@ -81,8 +81,8 @@ Install path frozen. No behavior change to `bin/install.js`, `install.sh`, `inst
 
 Uninstall: `npx ctxline-claude uninstall` removes only our two keys (guarded, backed up), deletes the hook, clears the cache. `install.sh`/`install.ps1` have no uninstall command — their printed manual-removal instructions must list both keys. No Full/Lite prompt or second statusline file.
 
-## Distribution + releasing
+## Distribution
 
 `statusline.js` is fetched verbatim from GitHub `main` by `install.sh`/`install.ps1` and copied by `bin/install.js` — a change on `main` ships to anyone re-running the installers; keep `main` releasable. `package.json` `files` whitelists what publishes.
 
-Releases are owner-triggered, manual: bump `version` in `package.json` **and the `VERSION` constant in `statusline.js`** on `main` (a test asserts they match), then run the **Release** workflow (`.github/workflows/release.yml`). Never `npm publish` by hand; never bump the version unasked.
+Version bump: `version` in `package.json` **and the `VERSION` constant in `statusline.js`**, on `main` (a test asserts they match).

--- a/statusline.js
+++ b/statusline.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-// Claude Code Enhanced Statusline
-// Shows: directory | model | context usage | 5-hour + weekly + model-scoped usage | current task
-// Auto-detects API key vs subscription usage
+// Claude Code statusline: dir │ model │ context │ usage │ cost │ task
 // https://github.com/MithunWijayasiri/ctxline-claude
 
 const fs = require('fs');
@@ -10,18 +8,13 @@ const os = require('os');
 const https = require('https');
 const { execSync, execFileSync, spawn } = require('child_process');
 
-// Installed version, compared against the npm registry's latest for the update nudge.
-// This file is copied standalone into ~/.claude/hooks/ with no package.json beside it,
-// so the version has to live here. Must match package.json "version" (see CLAUDE.md).
+// Lives here, not package.json: this file ships standalone to ~/.claude/hooks/. Must match package.json.
 const VERSION = '1.7.0';
 
 const IS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
 
-// Optional segment opt-out: CTXLINE_DISABLE is a comma list of segments to hide.
-// Recognized: branch, effort, cost, task, update, usage (H+W+model-scoped). dir/model/context
-// always render.
-// Unknown names are ignored. Disabling a segment also skips its work (git, todo read,
-// usage fetch).
+// Segment opt-out: comma list. Recognized: branch, effort, cost, task, update, usage.
+// Disabling skips the work, not just the output; dir/model/context always render.
 const DISABLED = new Set(
   (process.env.CTXLINE_DISABLE || '')
     .split(',')
@@ -29,40 +22,30 @@ const DISABLED = new Set(
     .filter(Boolean)
 );
 
-// Shared width (cells) for all progress bars: context, current, weekly.
+// Context bar width in cells.
 const BAR_WIDTH = 6;
 
-// Max characters shown for the git branch; longer names are tail-truncated with "…".
-// Tail-truncation keeps the start (ticket IDs like "TAMA5-32796" live there) visible.
+// Branch names tail-truncated to this with "…", keeping leading ticket IDs visible.
 const MAX_BRANCH_LEN = 24;
 
-// Separator between segments on a rendered line.
 const SEGMENT_SEP = ' │ ';
 
-// Cells reserved at the terminal edge when deciding to wrap to a second line.
-// 0 = use the full COLUMNS; bump it if Claude Code reserves columns and the line
-// truncates a char or two before wrapping.
+// Cells reserved at the terminal edge when deciding to wrap; 0 = full width.
 const WIDTH_MARGIN = 0;
 
 // Cache configuration
 const CACHE_DIR = path.join(os.homedir(), '.claude', 'cache');
 const USAGE_CACHE_FILE = path.join(CACHE_DIR, 'usage-cache.json');
-// Fresh: trust the cache and skip the API call entirely (fewer calls, faster render).
-const FRESH_TTL_MS = 30000;            // 30 seconds
-// Stale: used only as a fallback when a live API call fails, so the usage bar stays
-// visible through transient timeouts/errors instead of disappearing.
-const STALE_TTL_MS = 10 * 60 * 1000;   // 10 minutes
+const FRESH_TTL_MS = 30000;            // fresh: render cache, skip API
+const STALE_TTL_MS = 10 * 60 * 1000;   // stale: fallback only when a live call fails
 
-// Git ahead/behind cache (single repo entry, keyed by git dir). Throttles the one
-// `git rev-list` subprocess so a burst of renders in a turn runs it once, not per render.
+// Single-entry ahead/behind cache: throttles the one git subprocess to once per render burst.
 const GIT_CACHE_FILE = path.join(CACHE_DIR, 'git-cache.json');
 const GIT_FRESH_TTL_MS = 5000;          // 5s: reuse counts within a render burst
 const GIT_STALE_TTL_MS = 60000;         // 60s: fall back to last counts if git fails
 const GIT_TIMEOUT_MS = 500;             // hard cap on the rev-list subprocess (warm ~130ms)
 
-// Update check: compares VERSION against the npm registry's dist-tags.latest. The render
-// only ever reads this cache; the refresh runs in a detached child (see refreshUpdateCheck),
-// so no render ever waits on the registry.
+// Update check: render only reads this cache; the registry fetch runs in a detached child.
 const UPDATE_CACHE_FILE = path.join(CACHE_DIR, 'update-cache.json');
 const UPDATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;  // 7 days between successful checks
 const UPDATE_RETRY_MS = 60 * 60 * 1000;         // 1h backoff after a failed/killed check
@@ -71,8 +54,7 @@ const REGISTRY_HOST = 'registry.npmjs.org';
 const PACKAGE_NAME = 'ctxline-claude';
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;       // releases only: a prerelease never nudges
 
-// Subagent mode reads only stdin (no usage API to race), so its stdin read gets a
-// short hard cap of its own instead of the main-mode overallTimeout.
+// Subagent mode reads only stdin (no fetch to race), so its read gets its own short cap.
 const SUBAGENT_TIMEOUT_MS = 500;
 
 // ANSI color codes
@@ -88,9 +70,7 @@ const colors = {
   blink: '\x1b[5m'
 };
 
-// Color for the thinking-effort indicator. Levels rank low < medium < high < xhigh < max
-// < ultracode; only the top two are highlighted — "max" red, "ultracode" purple. Every
-// other level (including xhigh) renders dim like the rest of the metadata.
+// Levels rank low<medium<high<xhigh<max<ultracode; only max (red) and ultracode (purple) stand out.
 function getEffortColor(level) {
   const lvl = String(level).toLowerCase();
   if (lvl === 'max') return colors.red;
@@ -105,9 +85,7 @@ function getUsageColor(percentage) {
   return colors.red;
 }
 
-// Model-scoped bars skip the H/W thresholds: a line can carry several at once, so a flat
-// orange keeps them readable as one group. Red at >=90 is the one distinction kept — that
-// bar is about to block the model it names.
+// Flat orange keeps several scoped bars readable as one group; >=90 red flags a nearly-spent cap.
 function getScopedColor(percentage) {
   return percentage >= 90 ? colors.red : colors.orange;
 }
@@ -117,9 +95,7 @@ function shortenModel(name) {
   return name.replace(/\s+context\)/i, ')');
 }
 
-// Shorten a resolved model ID (subagent task.model, e.g. "claude-opus-5") for the
-// subagent row: "claude-opus-5" -> "Opus 5", "claude-haiku-4-5-20251001" -> "Haiku 4.5".
-// Distinct from shortenModel, which trims a display name rather than parsing an ID.
+// Resolved model ID -> "Opus 5" / "Haiku 4.5" (strips prefixes + trailing -YYYYMMDD).
 function shortenModelId(id) {
   if (!id) return '';
   const stripped = String(id).replace(/^(us\.)?(anthropic\.)?claude-/, '').replace(/-\d{8}$/, '');
@@ -135,8 +111,7 @@ function truncateBranch(name) {
   return name.length > MAX_BRANCH_LEN ? name.slice(0, MAX_BRANCH_LEN - 1) + '…' : name;
 }
 
-// Resolve the repo's git dir by walking up from `dir` (no `git` subprocess). Handles
-// worktrees/submodules (".git" as a file pointing at the real dir). '' on any failure.
+// Walks up from `dir` to the git dir (no subprocess); handles worktrees (".git" file). '' on failure.
 function resolveGitDir(dir) {
   let cur = dir;
   let gitPath = '';
@@ -158,16 +133,14 @@ function resolveGitDir(dir) {
   return gitPath;
 }
 
-// Current git branch, read straight from .git/HEAD (no `git` subprocess — fast,
-// dependency-free). Detached HEAD -> short sha. Best-effort: '' on any failure.
+// Branch read straight from .git/HEAD (no subprocess); detached HEAD -> short sha; '' on failure.
 function getGitBranch(dir) {
   try {
     const gitDir = resolveGitDir(dir);
     if (!gitDir) return '';
     const head = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
     const ref = head.match(/^ref:\s*refs\/heads\/(.+)$/);
-    // Strip control chars: HEAD is read raw (not git-validated), so a hand-crafted file
-    // in an untrusted archive could inject terminal escape sequences.
+    // HEAD is read raw, not git-validated: strip control chars (escape-sequence injection).
     if (ref) return truncateBranch(ref[1].replace(/[\x00-\x1f\x7f]/g, ''));
     if (/^[0-9a-f]{7,40}$/i.test(head)) return head.slice(0, 7);  // detached HEAD -> short sha
     return '';
@@ -176,8 +149,7 @@ function getGitBranch(dir) {
   }
 }
 
-// Read the cached ahead/behind for `gitDir`. Single-entry file: a different repo
-// invalidates it. Returns { age, ahead, behind } or null.
+// Cached ahead/behind for gitDir; different repo invalidates. { age, ahead, behind } or null.
 function readGitCache(gitDir) {
   try {
     const c = JSON.parse(fs.readFileSync(GIT_CACHE_FILE, 'utf8'));
@@ -196,10 +168,8 @@ function writeGitCache(gitDir, ahead, behind) {
   } catch (e) {}
 }
 
-// Commits ahead/behind the upstream (@{u}), cache-fronted. The single `git` call in the
-// whole script — gated by GIT_FRESH_TTL_MS so a render burst runs it once. No upstream /
-// detached / no git -> the subprocess errors -> null (segment omitted). On a slow/failed
-// call, falls back to the last counts up to GIT_STALE_TTL_MS so they don't flicker.
+// The only `git` subprocess, cache-fronted. null on no upstream/detached/failed (segment omitted);
+// slow/failed call falls back to last counts up to GIT_STALE_TTL_MS so counts don't flicker.
 function getGitAheadBehind(dir) {
   const gitDir = resolveGitDir(dir);
   if (!gitDir) return null;
@@ -210,8 +180,7 @@ function getGitAheadBehind(dir) {
   }
 
   try {
-    // execFileSync (no shell): faster cold spawn than execSync and passes `@{u}` literally.
-    // `@{u}...HEAD` with --left-right --count prints "<behind>\t<ahead>" (left = upstream).
+    // No shell (faster cold spawn, @{u} literal); --left-right --count prints "<behind>\t<ahead>".
     const out = execFileSync('git', ['rev-list', '--left-right', '--count', '@{u}...HEAD'], {
       cwd: dir, encoding: 'utf8', timeout: GIT_TIMEOUT_MS, stdio: ['ignore', 'pipe', 'ignore']
     }).trim();
@@ -231,9 +200,7 @@ function getGitAheadBehind(dir) {
   }
 }
 
-// "↑N↓M" from ahead/behind counts: ahead green (commits to push), behind red (missing
-// commits). Each part self-resets so it doesn't inherit the dim branch color. Omit a zero
-// side; '' when in sync or null.
+// "↑N↓M": ahead green, behind red, zero side omitted; '' when in sync or null.
 function formatAheadBehind(ab) {
   if (!ab) return '';
   let s = '';
@@ -242,15 +209,11 @@ function formatAheadBehind(ab) {
   return s;
 }
 
-// Colored "C<used> <bar>" (e.g. "C45 ███░░░") for an already-clamped 0-100 used
-// percentage. Shared by the main context bar (derived from remaining%) and the
-// subagent row (derived from tokenCount/contextWindowSize) so both use the same
-// thresholds and bar style.
+// Colored "C<used> <bar>" (e.g. "C45 ███░░░"); shared by main line and subagent rows.
 function renderContextBar(used) {
   const filled = Math.round((used / 100) * BAR_WIDTH);
   const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(BAR_WIDTH - filled);
 
-  // Context color: green <50 / yellow <65 / orange <80 / blink-red >=80.
   let color;
   if (used < 50) color = colors.green;
   else if (used < 65) color = colors.yellow;
@@ -271,10 +234,8 @@ function renderModelEffort(model, effort) {
   return effort ? `${model}${getEffortColor(effort)} · ${effort}${colors.reset}` : model;
 }
 
-// Render a compact usage segment from raw data: "<label><pct> ↺ <countdown>"
-// (e.g. "H81 ↺ 2h21m") — no bar. Called on every read (live or cached) so the reset
-// countdown is always recomputed from resetsAt rather than frozen at fetch time.
-// `color` overrides the threshold color — the model-scoped bars pass getScopedColor.
+// "<label><pct> ↺ <countdown>" (e.g. "H81 ↺ 2h21m"), no bar. Called on every read so the
+// countdown recomputes from resetsAt; `color` overrides the thresholds (scoped bars).
 function buildUsageBar(label, percentage, resetsAt, color) {
   let timeStr = '';
   if (resetsAt) {
@@ -293,32 +254,16 @@ function buildUsageBar(label, percentage, resetsAt, color) {
   return `${barColor}${label}${percentage}${colors.reset}${timePart}`;
 }
 
-// Model-scoped weekly limits (e.g. "Fable weekly limit at 86%"), rendered after the
-// account-wide W bar. The /usage payload reports these in a `limits` array, each entry
-// carrying the model in scope.model.display_name:
-//
-//   { kind: "weekly_scoped", percent: 86, severity: "warning",
-//     resets_at: "...", scope: { model: { display_name: "Fable" } } }
-//
-// The label is the model's first initial (Fable -> F), so a new model family needs no
-// code change. Older payloads instead exposed flat seven_day_<model> keys, kept below as
-// a fallback for accounts still reporting that shape.
-//
-// NOTE: these appear only in the API payload. Claude Code's statusline stdin carries just
-// five_hour and seven_day under rate_limits, so the scoped limits always come from the
-// cache/API path even when stdin supplies the H and W bars.
+// Model-scoped weekly limits, rendered after W. /usage payload `limits[]` entries:
+//   { kind: "weekly_scoped", percent, resets_at, scope: { model: { display_name } } }
+// Label = first initial of the model name (Fable -> F). Legacy flat seven_day_<model> keys
+// kept as fallback. Only ever in the API payload — stdin rate_limits never carries them.
 const LEGACY_MODEL_WEEKLY_KEYS = [
   { key: 'seven_day_opus', label: 'O' },
   { key: 'seven_day_sonnet', label: 'S' }
 ];
 
-// Build the usage segments from a raw { fiveHour, weekly, models } object — the shared
-// shape both buildUsageFromStdin and parseUsagePayload return. fiveHour/weekly are
-// { percentage, resetsAt } or null/absent; models is an array of { label, percentage,
-// resetsAt } (possibly empty). Returns { current, weekly, models } — the first two
-// rendered strings or null, models a (possibly empty) array of rendered strings. Scoped
-// bars use getScopedColor instead of the H/W thresholds, so the full threshold palette
-// stays exclusive to H/W.
+// Raw { fiveHour, weekly, models } -> rendered segments; scoped bars use getScopedColor.
 function buildUsageBars(raw) {
   const { fiveHour, weekly, models } = raw || {};
   return {
@@ -328,18 +273,13 @@ function buildUsageBars(raw) {
   };
 }
 
-// Normalize a raw API utilization into the 0-100 integer that the rest of the
-// pipeline (cache validation + bar rendering) expects. Returns null when the value
-// isn't a finite number, so callers can omit that bar instead of rendering "NaN%".
+// Clamp to 0-100 int; null on non-finite so callers omit the bar instead of rendering "NaN%".
 function normalizePercentage(value) {
   if (!Number.isFinite(value)) return null;
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-// Extract the model-scoped weekly limits from a raw /usage payload as
-// [{ label, percentage, resetsAt }], in payload order. Prefers the `limits` array;
-// falls back to the legacy flat keys only when it yields nothing, so an account
-// reporting both shapes doesn't render the same limit twice.
+// limits[] -> [{ label, percentage, resetsAt }]; legacy flat keys only when limits yields nothing.
 function parseScopedLimits(usage) {
   const scoped = [];
 
@@ -366,13 +306,9 @@ function parseScopedLimits(usage) {
   return scoped;
 }
 
-// Build usage bars from stdin `rate_limits` (Claude.ai Pro/Max, present only after the
-// first API response of a session). Same data as the OAuth usage API, so reading it here
-// skips the network/credentials/cache path entirely. `resets_at` is a Unix epoch in
-// SECONDS (not ISO) — ×1000 before Date. Returns raw { fiveHour, weekly, models } — same
-// shape as parseUsagePayload — or null when rate_limits is absent or the required
-// five_hour segment is unusable (caller falls back). models is always [] here: model-scoped
-// weekly limits are never present in stdin — see LEGACY_MODEL_WEEKLY_KEYS.
+// Usage from stdin `rate_limits` (Pro/Max only, absent at cold start) — skips the
+// network/cache path entirely. resets_at is Unix epoch SECONDS (not ISO). Same raw shape as
+// parseUsagePayload; models always [] — scoped limits never arrive via stdin.
 function buildUsageFromStdin(data) {
   const rl = data?.rate_limits;
   if (!rl) return null;
@@ -381,9 +317,7 @@ function buildUsageFromStdin(data) {
     if (!seg) return null;
     const pct = normalizePercentage(seg.used_percentage);
     if (pct == null) return null;
-    // resets_at is a Unix epoch in SECONDS. Coerce + validate defensively: a non-numeric
-    // or out-of-range value would make new Date(...).toISOString() throw, and this path
-    // runs outside outputStatus's try/catch. Fall back to resetsAt: null on anything bad.
+    // Defensive: this path runs outside outputStatus's try/catch — bad value -> null, never a throw.
     let resetsAt = null;
     const epoch = Number(seg.resets_at);
     if (Number.isFinite(epoch) && epoch > 0) {
@@ -398,11 +332,9 @@ function buildUsageFromStdin(data) {
   return { fiveHour, weekly: toEntry(rl.seven_day), models: [] };
 }
 
-// Parse a raw /usage API response body into { fiveHour, weekly, models } — same shape as
-// buildUsageFromStdin — or null on unparseable JSON or a missing/non-finite five_hour
-// utilization (that bar is required). Normalizes utilization first so a missing/non-finite
-// value omits a bar instead of rendering "NaN%". Pure — no fs/network — so it's unit
-// testable directly, unlike getApiUsage which needs a live socket.
+// /usage response body -> { fiveHour, weekly, models }, or null on unparseable JSON or a
+// missing/non-finite five_hour utilization (that bar is required). Pure, so unit-testable
+// directly — unlike getApiUsage, which needs a live socket.
 function parseUsagePayload(body) {
   try {
     const usage = JSON.parse(body);
@@ -420,8 +352,7 @@ function parseUsagePayload(body) {
   }
 }
 
-// Validate a single usage entry ({ percentage, resetsAt }). Returns true only for a
-// finite 0-100 percentage and a parseable (or absent) resetsAt.
+// Valid entry: finite 0-100 percentage, parseable (or absent) resetsAt.
 function isValidUsageEntry(entry) {
   if (!entry || typeof entry !== 'object') return false;
   if (!Number.isFinite(entry.percentage) || entry.percentage < 0 || entry.percentage > 100) return false;
@@ -429,9 +360,7 @@ function isValidUsageEntry(entry) {
   return true;
 }
 
-// Read the raw cached usage data
-// ({ timestamp, data: { fiveHour: {percentage,resetsAt}, weekly: {...}|null } }).
-// Returns { age, data } or null. Age-vs-TTL decisions are made by the caller.
+// Cached usage -> { age, data } or null; caller applies TTLs. Invalid shape -> null.
 function readCachedUsage() {
   try {
     if (!fs.existsSync(USAGE_CACHE_FILE)) return null;
@@ -439,10 +368,7 @@ function readCachedUsage() {
     const cache = JSON.parse(fs.readFileSync(USAGE_CACHE_FILE, 'utf8'));
     if (!cache || !Number.isFinite(cache.timestamp) || cache.timestamp <= 0) return null;
 
-    // Validate data. fiveHour is required; weekly and models are optional (the API may
-    // omit either). This also rejects the legacy single-{percentage,resetsAt} format from
-    // older versions, which had no fiveHour key, so stale caches are ignored on read.
-    // A cache written before model bars existed simply has no models key — still valid.
+    // fiveHour required; weekly/models optional. Rejects legacy formats lacking fiveHour.
     const data = cache.data;
     if (!data || typeof data !== 'object') return null;
     if (!isValidUsageEntry(data.fiveHour)) return null;
@@ -458,11 +384,8 @@ function readCachedUsage() {
   }
 }
 
-// Serialize usage data into the on-disk cache shape ({ timestamp, data, lastAttempt }). Pure
-// -- no fs -- so setCachedUsage and the test/preview cache seeds all produce exactly the same
-// bytes the real writer would; a reader/writer format mismatch becomes structurally impossible
-// instead of merely untested. `timestamp` defaults to now; tests override it to seed a stale
-// cache. A successful write is itself an attempt, so `lastAttempt` starts equal to `timestamp`.
+// On-disk cache shape; pure so test/preview seeds produce writer-identical bytes. lastAttempt
+// starts equal to timestamp: a successful write is itself an attempt.
 function serializeUsageCache(data, timestamp = Date.now()) {
   return JSON.stringify({ timestamp, data, lastAttempt: timestamp });
 }
@@ -480,9 +403,8 @@ function setCachedUsage(data) {
   }
 }
 
-// Age in ms since the last API attempt (success or failure), or null if none recorded yet.
-// Read directly from the raw file rather than via readCachedUsage so the cooldown still
-// applies when no valid data has ever been cached (every attempt so far has failed).
+// Age in ms since the last attempt (success or failure), or null. Read from the raw file, not
+// readCachedUsage, so the cooldown applies even when no valid data has ever been cached.
 function getLastAttemptAge() {
   try {
     if (!fs.existsSync(USAGE_CACHE_FILE)) return null;
@@ -494,9 +416,8 @@ function getLastAttemptAge() {
   }
 }
 
-// Record that an API attempt is starting, preserving any existing cached data/timestamp so a
-// failed refresh doesn't erase the last successful one. Written before the request so a hang
-// or a process exit mid-request still counts as an attempt for cooldown purposes.
+// Stamp lastAttempt before the request so failed attempts still enter cooldown; preserves
+// existing cached data so a failed refresh doesn't erase the last successful one.
 function recordUsageAttempt() {
   try {
     if (!fs.existsSync(CACHE_DIR)) {
@@ -514,9 +435,7 @@ function recordUsageAttempt() {
   }
 }
 
-// Compare two strict "x.y.z" versions -> -1 | 0 | 1, or null when either side isn't that
-// shape (prerelease tags, missing parts, non-numeric). The nudge is a nicety, so an
-// unparseable version means no segment rather than a guess.
+// Strict "x.y.z" -> -1|0|1, null otherwise (prerelease never nudges — a nicety, not a guess).
 function compareVersions(a, b) {
   const parse = (v) => SEMVER_RE.test(String(v ?? '')) ? String(v).split('.').map(Number) : null;
   const x = parse(a);
@@ -528,8 +447,7 @@ function compareVersions(a, b) {
   return 0;
 }
 
-// Pure: an npm registry version-manifest body -> its "x.y.z" version string, or null on
-// unparseable JSON, a missing version, or a non-release version (404 bodies land here too).
+// Registry body -> "x.y.z" or null (404 bodies land here too).
 function parseRegistryVersion(body) {
   try {
     const v = JSON.parse(body)?.version;
@@ -555,18 +473,15 @@ function writeUpdateCache(obj) {
   } catch (e) {}
 }
 
-// The cached latest version when it's newer than VERSION, else ''. Cache-only by design:
-// collectFacts calls this on the render path, and the render must never touch the network.
+// Cached latest when strictly newer than VERSION, else ''. Cache-only: render never touches the network.
 function getLatestUpdate() {
   const cached = readUpdateCache();
   if (!cached) return '';
   return compareVersions(cached.latest, VERSION) === 1 ? String(cached.latest) : '';
 }
 
-// Fire the weekly check in a detached child, so the render neither waits on the registry
-// nor races its own exit against the response. lastAttempt is stamped before the spawn, so
-// an offline machine, a failed spawn, or a child that dies backs off UPDATE_RETRY_MS
-// instead of respawning on every render.
+// Spawn the check in a detached child — the render never waits on the registry. lastAttempt is
+// stamped before the spawn, so an offline/failed/killed child backs off UPDATE_RETRY_MS.
 function refreshUpdateCheck() {
   try {
     const cached = readUpdateCache();
@@ -576,18 +491,15 @@ function refreshUpdateCheck() {
       if (Number.isFinite(cached.lastAttempt) && now - cached.lastAttempt < UPDATE_RETRY_MS) return;
     }
     writeUpdateCache({ ...(cached || {}), lastAttempt: now });
-    // windowsHide: a detached console app would otherwise flash its own console window on
-    // Windows. detached + unref so the child outlives this render's exit(0).
+    // windowsHide: no console flash on Windows; detached + unref: child outlives the render's exit.
     spawn(process.execPath, [__filename, 'update-check'], {
       detached: true, stdio: 'ignore', windowsHide: true
     }).unref();
   } catch (e) {}
 }
 
-// The 'update-check' entry point: the detached child. Fetches the registry's latest
-// version, stamps the cache, exits. Writes nothing to stdout — it is not a statusline
-// mode, and its stdio is discarded by the parent anyway. A failed fetch leaves checkedAt
-// untouched, so the UPDATE_RETRY_MS backoff (not the weekly TTL) governs the next try.
+// Detached 'update-check' entry point: fetch, stamp cache, exit. A failed fetch leaves
+// checkedAt untouched, so the UPDATE_RETRY_MS backoff (not the weekly TTL) governs the next try.
 function runUpdateCheck() {
   let settled = false;
   let deadline;
@@ -619,9 +531,7 @@ function runUpdateCheck() {
       done(null);
     });
 
-    // The `timeout` option above is socket inactivity, not total duration -- a response
-    // that trickles bytes would keep this detached child alive indefinitely, and the
-    // parent's UPDATE_RETRY_MS only delays the next spawn, it can't reap this one.
+    // The timeout option is socket inactivity, not total — a trickling response needs this hard deadline.
     deadline = setTimeout(() => {
       req.destroy();
       done(null);
@@ -634,7 +544,6 @@ function runUpdateCheck() {
 }
 
 function getCredentials() {
-  // Try file first (legacy / Linux / Windows)
   const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
   if (fs.existsSync(credsPath)) {
     try {
@@ -642,7 +551,7 @@ function getCredentials() {
     } catch (e) {}
   }
 
-  // Fallback: macOS keychain
+  // macOS keychain fallback
   if (os.platform() === 'darwin') {
     try {
       const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null', { encoding: 'utf8', timeout: 1000 });
@@ -655,7 +564,6 @@ function getCredentials() {
 
 function getApiUsage(callback) {
   try {
-    // Read credentials (file or macOS keychain)
     const creds = getCredentials();
     if (!creds) {
       return callback(null);
@@ -667,12 +575,10 @@ function getApiUsage(callback) {
       return callback(null);
     }
 
-    // Adaptive timeout: if cache exists, be faster (1200ms); if not, be patient (1500ms)
-    // API typically takes ~850ms, so 1200ms gives reasonable headroom
+    // Tighter timeout when the cache is warm — a fresh render already has data to print.
     const hasCache = fs.existsSync(USAGE_CACHE_FILE);
     const timeout = hasCache ? 1200 : 1500;
 
-    // Make API call with adaptive timeout
     const req = https.request({
       hostname: 'api.anthropic.com',
       path: '/api/oauth/usage',
@@ -689,7 +595,6 @@ function getApiUsage(callback) {
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
         const resolved = parseUsagePayload(data);
-        // Cache the raw data (shared across sessions); callers render from it.
         if (resolved) setCachedUsage(resolved);
         callback(resolved);
       });
@@ -711,27 +616,21 @@ function getApiUsage(callback) {
 function getRawUsage(callback) {
   const cached = readCachedUsage();
 
-  // Cache is fresh -> use it and skip the API entirely (fewer calls, faster).
   if (cached && cached.age < FRESH_TTL_MS) {
     return callback(cached.data);
   }
 
-  // A refresh (successful or not) was attempted within FRESH_TTL_MS -> still in cooldown,
-  // don't hit the API again. Serve stale cached data if it's still within STALE_TTL_MS, else
-  // nothing. Without this, a repeatedly failing/timing-out refresh would re-hit the API on
-  // every render instead of backing off (issue #41).
+  // Refresh attempted (even failed) within FRESH_TTL_MS -> cooldown: serve stale up to STALE_TTL_MS (issue #41).
   const attemptAge = getLastAttemptAge();
   if (attemptAge != null && attemptAge < FRESH_TTL_MS) {
     return callback(cached && cached.age < STALE_TTL_MS ? cached.data : null);
   }
 
-  // Cache is stale or missing and no attempt is in cooldown -> refresh from the API.
   recordUsageAttempt();
   getApiUsage((fresh) => {
     if (fresh) {
       callback(fresh);
     } else if (cached && cached.age < STALE_TTL_MS) {
-      // API failed/timed out, but recent cache exists -> show it instead of nothing.
       callback(cached.data);
     } else {
       callback(null);
@@ -739,9 +638,7 @@ function getRawUsage(callback) {
   });
 }
 
-// Session cost from stdin `cost.total_cost_usd` (USD float, computed client-side by
-// Claude Code as tokens × per-model API pricing). Pure stdin — no network/cache.
-// Returns "$0.00" rendered dim, or '' when absent/non-finite so the segment is omitted.
+// "$0.00" (dim) from stdin cost.total_cost_usd — client-side estimate, no network; '' when absent.
 function getCostSegment(data) {
   const usd = data?.cost?.total_cost_usd;
   if (!Number.isFinite(usd)) return '';
@@ -777,11 +674,8 @@ function visibleWidth(str) {
   return [...str.replace(/\x1b\[[0-9;]*m/g, '')].length;
 }
 
-// Responsive layout: one line when it fits the terminal, else line1 (identity + context)
-// on top and line2 (usage/cost/task) below. Splits only when cols is known (Claude Code
-// v2.1.153+ sets COLUMNS, read by collectFacts) and the single line overflows — unknown
-// width or an empty line2 stays single, so there is no regression on older clients or wide
-// terminals.
+// Two lines only when cols is known (COLUMNS, set by Claude Code v2.1.153+) and the single
+// line overflows; unknown width or empty line2 stays single. cols is a parameter — no env read.
 function layout(line1Parts, line2Parts, cols) {
   const single = [...line1Parts, ...line2Parts].join(SEGMENT_SEP);
   if (line2Parts.length === 0) return single;
@@ -791,12 +685,9 @@ function layout(line1Parts, line2Parts, cols) {
   return single;
 }
 
-// Gathers everything outputStatus needs that touches fs/child_process/env: git branch +
-// ahead/behind (.git/HEAD, `git rev-list`), the in-progress task (~/.claude/todos), and the
-// terminal width (COLUMNS). Kept separate from renderStatusLine so the render step is pure.
-// Wrapped in its own try/catch (unlike renderStatusLine, it's called outside outputStatus's
-// try/catch in emit()) — a malformed workspace.current_dir (e.g. non-string) can throw from
-// path.basename or resolveGitDir, and this must still degrade to a renderable fallback.
+// Everything the render needs that touches fs/child_process/env (git, todos, update cache,
+// COLUMNS), so renderStatusLine stays pure. Own try/catch: called outside outputStatus's, and
+// a malformed current_dir must still degrade to a renderable fallback.
 function collectFacts(data) {
   try {
     const dir = data?.workspace?.current_dir || process.cwd();
@@ -813,19 +704,15 @@ function collectFacts(data) {
   }
 }
 
-// The update nudge gets its own row rather than a segment: Claude Code renders every
-// stdout line as a separate row, and the point of the nudge is the copy-pasteable command,
-// which is too wide to inline without forcing the main line to wrap on most terminals.
-// `npx <pkg>@latest` is the right command for script-installed users too — it recopies the
-// hook. Only the target version is shown — the running one is what you're looking at.
+// Own stdout row, not a segment: the copy-pasteable command is too wide to inline without
+// forcing a wrap. Appended after layout() so it never joins the wrap decision.
 function renderUpdateLine(latest) {
   return `${colors.green}⬆ ${latest}${colors.reset} `
     + `${colors.dim}available ·${colors.reset} `
     + `${colors.bold}npx ${PACKAGE_NAME}@latest${colors.reset}`;
 }
 
-// Pure: data + facts (see collectFacts) + resolved usage bars -> the rendered line(s).
-// No fs/child_process/network access, so it's callable directly in tests.
+// Pure: data + facts (see collectFacts) + usage bars -> rendered line(s); callable directly in tests.
 function renderStatusLine(data, facts, usage) {
   const model = shortenModel(data?.model?.display_name || 'Claude');
   const effort = DISABLED.has('effort') ? '' : (data?.effort?.level || '');
@@ -853,7 +740,6 @@ function renderStatusLine(data, facts, usage) {
   return facts.update ? body + '\n' + renderUpdateLine(facts.update) : body;
 }
 
-// Main
 function outputStatus(data, facts, usage) {
   try {
     process.stdout.write(renderStatusLine(data, facts, usage));
@@ -867,20 +753,15 @@ function outputFallback(usage) {
   process.stdout.write(renderStatusLine(null, facts, usage));
 }
 
-// Resolve usage bars for a (possibly null) parsed stdin payload.
-// Order: API-key users get none; otherwise prefer stdin `rate_limits` (no network),
-// then fall back to the cache+API flow when stdin lacks it (cold start / non-Pro/Max).
+// Usage bars: API-key users none; prefer stdin rate_limits, else cache+API (cold start / non-Pro/Max).
 function resolveUsage(data, callback) {
   if (IS_API_KEY || DISABLED.has('usage')) {
     return callback(null);
   }
   const fromStdin = buildUsageFromStdin(data);
   if (fromStdin) {
-    // stdin covers H and W with no network. Model-scoped weekly limits only exist in the
-    // API payload, so they come from the cache — refreshed on the same TTL as every other
-    // usage read, which keeps at most one call per FRESH_TTL_MS regardless of render rate.
-    // Falls back to the stale cache and finally to [] so a failed or slow call costs only
-    // the scoped bars, never the H/W bars stdin already gave us.
+    // Scoped limits only exist in the API payload -> fetch from cache; a failed/slow call
+    // costs only those bars, never the H/W bars stdin already gave us.
     return getRawUsage((cached) => {
       callback(buildUsageBars({ ...fromStdin, models: cached?.models || [] }));
     });
@@ -898,10 +779,8 @@ function parseInput(input) {
   }
 }
 
-// Accumulate stdin then call fn(input) exactly once, on whichever fires first:
-// timeout, 'end', or 'error' (an unhandled stdin error would otherwise throw,
-// breaking the never-throw contract). Shared by both entry points below, which
-// differ only in timeoutMs.
+// Accumulate stdin, call fn(input) exactly once — timeout, 'end', or 'error' whichever fires
+// first (the error handler preserves the never-throw contract). Shared by both entry points.
 function readStdinThen(timeoutMs, fn) {
   let input = '';
   let finished = false;
@@ -934,10 +813,8 @@ function emit(data) {
   });
 }
 
-// now - startTime as "45s" / "4m12s" / "2h5m". '' when startTime is missing/unparseable.
-// Format isn't documented by Claude Code, so accept epoch-seconds, epoch-ms, or an ISO
-// string: numbers below 1e12 are epoch-seconds (today's epoch-seconds ~1.7e9, epoch-ms
-// ~1.7e12 — far enough apart that the threshold is unambiguous for any real timestamp).
+// "45s" / "4m12s" / "2h5m". startTime's format is undocumented upstream, so accept epoch-seconds
+// (< 1e12), epoch-ms, or an ISO string. Revisit if a real payload contradicts.
 function formatElapsed(startTime) {
   if (startTime == null) return '';
   const ms = typeof startTime === 'number' && startTime < 1e12 ? startTime * 1000 : startTime;
@@ -978,10 +855,8 @@ function renderSubagentTask(t) {
   return parts.join(SEGMENT_SEP);
 }
 
-// subagentStatusLine mode: emit one {id, content} JSON line per task with an id, then
-// exit. No usage/git/todos/cache work — the task objects carry everything needed.
-// Bad payload or a task that fails to render -> emit nothing, keeping default
-// rendering for every task, rather than a partial/broken output.
+// subagentStatusLine mode: one {id, content} JSON line per task. No usage/git/todos/cache
+// work. Bad payload or a task that fails to render -> emit nothing (default rendering stays).
 function emitSubagent(data) {
   try {
     const tasks = Array.isArray(data?.tasks) ? data.tasks : [];
@@ -990,9 +865,7 @@ function emitSubagent(data) {
       .map(t => JSON.stringify({ id: t.id, content: renderSubagentTask(t) }))
       .join('\n');
     if (out) {
-      // Exit from the write callback: process.exit() would drop output still queued
-      // behind stdout backpressure. A write error (e.g. EPIPE) also lands here — the
-      // callback form reports it instead of throwing, and the answer is the same: exit 0.
+      // Exit from the write callback: process.exit() would drop output queued behind backpressure.
       process.stdout.write(out + '\n', () => process.exit(0));
       return;
     }
@@ -1000,16 +873,13 @@ function emitSubagent(data) {
   process.exit(0);
 }
 
-// Entry point, guarded so tests can require this file to exercise payload parsing
-// directly (the /usage response shape is the easiest thing here to get wrong, and it
-// can't be reached through stdin). Running the script normally is unchanged.
+// Guarded so tests can require() the exports instead of spawning the script.
 if (require.main === module) {
   const mode = process.argv[2];
   const isSubagent = mode === 'subagent';
   const finish = isSubagent ? emitSubagent : emit;
 
   if (mode === 'update-check') {
-    // Detached child spawned by refreshUpdateCheck: no stdin, no output, just the fetch.
     runUpdateCheck();
   } else if (process.stdin.isTTY) {
     finish(null);


### PR DESCRIPTION
Closes #48. Follows the CodeRabbit checklist on that issue — selective reduction, no blanket deletion.

## Changes

**`statusline.js`** (comments only — executable code unchanged, verified by comment-stripped diff)
- Comment lines 227 → 97 (file 1024 → 894): multi-line walkthroughs compressed to one-liners, restatements of visible code removed.
- Kept all operational invariants: never-throw/timing contract, `lastAttempt` stamped before request/spawn, `resets_at` epoch-seconds, scoped-limits-API-only, cache-only render path, write-callback exit, worktree/detached-HEAD handling, escape-injection guard.
- Data-shape docs kept at boundaries only (`buildUsageFromStdin`, `parseUsagePayload`, `LEGACY_MODEL_WEEKLY_KEYS`).
- Fixed stale `BAR_WIDTH` comment (claimed 3 users; has 1).

**`CLAUDE.md`** (146 → 88 lines)
- Kept: format diagram, commands, execution contract + stdin fields, sync table + triggers, non-goals, frozen installers, release process.
- Dropped: segment-gotcha table, usage/update/cache/subagent deep-dives, visible-contract paragraph — delegated to `.claude/skills/restyle-statusline/SKILL.md`.
- Sync row for CLAUDE.md updated in SKILL.md to match.

## Validation

- `npm test` — 99/99 pass
- `npm run preview` — all scenarios render unchanged
- CodeRabbit preservation checklist verified present in new CLAUDE.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Condensed project and statusline reference documentation while preserving essential operational guidance.
  - Clarified statusline rendering behavior, including usage refresh timing and cache handling.
  - Updated synchronization guidance to cover timing and TTL values, stdin fields, exports, and render-logic responsibilities.
  - Streamlined inline statusline documentation for improved readability.
  - Clarified context color rendering and label-placement guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->